### PR TITLE
fix: Bad performance for intensive editing

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -28,6 +28,13 @@
 		"plugin:react-hooks/recommended"
 	],
 	"rules": {
+		"react-hooks/exhaustive-deps": [
+			"warn",
+			{
+				// custom hooks with deps
+				"additionalHooks": "(useImmutableCallback)"
+			}
+		],
 		// turn on errors for missing imports
 		"local-rules/proper-import-aliases": "error",
 		"import/no-unresolved": "error",

--- a/.eslintrc
+++ b/.eslintrc
@@ -69,6 +69,7 @@
 					"vite",
 					"Workspace",
 					"Xmark",
+					"Virtualizer",
 					"Yaml",
 					"aes",
 					"backtick",

--- a/package-lock.json
+++ b/package-lock.json
@@ -16,6 +16,7 @@
 				"@lexical/react": "^0.19.0",
 				"@popperjs/core": "^2.11.8",
 				"@reduxjs/toolkit": "^2.2.7",
+				"@tanstack/react-virtual": "^3.11.2",
 				"@types/mdast": "^4.0.4",
 				"better-sqlite3": "^9.6.0",
 				"crc": "^4.3.2",
@@ -6579,6 +6580,33 @@
 			},
 			"engines": {
 				"node": ">=10"
+			}
+		},
+		"node_modules/@tanstack/react-virtual": {
+			"version": "3.11.2",
+			"resolved": "https://registry.npmjs.org/@tanstack/react-virtual/-/react-virtual-3.11.2.tgz",
+			"integrity": "sha512-OuFzMXPF4+xZgx8UzJha0AieuMihhhaWG0tCqpp6tDzlFwOmNBPYMuLOtMJ1Tr4pXLHmgjcWhG6RlknY2oNTdQ==",
+			"license": "MIT",
+			"dependencies": {
+				"@tanstack/virtual-core": "3.11.2"
+			},
+			"funding": {
+				"type": "github",
+				"url": "https://github.com/sponsors/tannerlinsley"
+			},
+			"peerDependencies": {
+				"react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+				"react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+			}
+		},
+		"node_modules/@tanstack/virtual-core": {
+			"version": "3.11.2",
+			"resolved": "https://registry.npmjs.org/@tanstack/virtual-core/-/virtual-core-3.11.2.tgz",
+			"integrity": "sha512-vTtpNt7mKCiZ1pwU9hfKPhpdVO2sVzFQsxoVBGtOSHxlrRRzYr8iQ2TlwbAcRYCcEiZ9ECAM8kBzH0v2+VzfKw==",
+			"license": "MIT",
+			"funding": {
+				"type": "github",
+				"url": "https://github.com/sponsors/tannerlinsley"
 			}
 		},
 		"node_modules/@tootallnate/once": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -91,6 +91,7 @@
 				"css-loader": "^6.8.1",
 				"electron": "^25.9.8",
 				"electron-builder": "^24.13.3",
+				"electron-devtools-installer": "^4.0.0",
 				"eslint": "^8.40.0",
 				"eslint-import-resolver-typescript": "^3.6.1",
 				"eslint-plugin-import": "^2.29.1",
@@ -11422,6 +11423,16 @@
 				"node": ">=12"
 			}
 		},
+		"node_modules/electron-devtools-installer": {
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/electron-devtools-installer/-/electron-devtools-installer-4.0.0.tgz",
+			"integrity": "sha512-9Tntu/jtfSn0n6N/ZI6IdvRqXpDyLQiDuuIbsBI+dL+1Ef7C8J2JwByw58P3TJiNeuqyV3ZkphpNWuZK5iSY2w==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"unzip-crx-3": "^0.2.0"
+			}
+		},
 		"node_modules/electron-installer-common": {
 			"version": "0.10.3",
 			"resolved": "https://registry.npmjs.org/electron-installer-common/-/electron-installer-common-0.10.3.tgz",
@@ -14917,6 +14928,13 @@
 				"node": "^14.17.0 || ^16.13.0 || >=18.0.0"
 			}
 		},
+		"node_modules/immediate": {
+			"version": "3.0.6",
+			"resolved": "https://registry.npmjs.org/immediate/-/immediate-3.0.6.tgz",
+			"integrity": "sha512-XXOFtyqDjNDAQxVfYxuF7g9Il/IbWmmlQg2MYKOH8ExIT1qg6xc4zyS3HaEEATgs1btfzxq15ciUiY7gjSXRGQ==",
+			"dev": true,
+			"license": "MIT"
+		},
 		"node_modules/immer": {
 			"version": "10.1.1",
 			"resolved": "https://registry.npmjs.org/immer/-/immer-10.1.1.tgz",
@@ -15896,6 +15914,59 @@
 				"node": ">=4.0"
 			}
 		},
+		"node_modules/jszip": {
+			"version": "3.10.1",
+			"resolved": "https://registry.npmjs.org/jszip/-/jszip-3.10.1.tgz",
+			"integrity": "sha512-xXDvecyTpGLrqFrvkrUSoxxfJI5AH7U8zxxtVclpsUtMCq4JQ290LY8AW5c7Ggnr/Y/oK+bQMbqK2qmtk3pN4g==",
+			"dev": true,
+			"license": "(MIT OR GPL-3.0-or-later)",
+			"dependencies": {
+				"lie": "~3.3.0",
+				"pako": "~1.0.2",
+				"readable-stream": "~2.3.6",
+				"setimmediate": "^1.0.5"
+			}
+		},
+		"node_modules/jszip/node_modules/isarray": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+			"integrity": "sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/jszip/node_modules/readable-stream": {
+			"version": "2.3.8",
+			"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.8.tgz",
+			"integrity": "sha512-8p0AUk4XODgIewSi0l8Epjs+EVnWiK7NoDIEGU0HhE7+ZyY8D1IMY7odu5lRrFXGg71L15KG8QrPmum45RTtdA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"core-util-is": "~1.0.0",
+				"inherits": "~2.0.3",
+				"isarray": "~1.0.0",
+				"process-nextick-args": "~2.0.0",
+				"safe-buffer": "~5.1.1",
+				"string_decoder": "~1.1.1",
+				"util-deprecate": "~1.0.1"
+			}
+		},
+		"node_modules/jszip/node_modules/safe-buffer": {
+			"version": "5.1.2",
+			"resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+			"integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/jszip/node_modules/string_decoder": {
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+			"integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"safe-buffer": "~5.1.0"
+			}
+		},
 		"node_modules/junk": {
 			"version": "3.1.0",
 			"resolved": "https://registry.npmjs.org/junk/-/junk-3.1.0.tgz",
@@ -16095,6 +16166,16 @@
 			"funding": {
 				"type": "GitHub Sponsors ❤",
 				"url": "https://github.com/sponsors/dmonad"
+			}
+		},
+		"node_modules/lie": {
+			"version": "3.3.0",
+			"resolved": "https://registry.npmjs.org/lie/-/lie-3.3.0.tgz",
+			"integrity": "sha512-UaiMJzeWRlEujzAuw5LokY1L5ecNQYZKfmyZ9L7wDHb/p5etKaxXhohBcrw0EYby+G/NA52vRSN4N39dxHAIwQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"immediate": "~3.0.5"
 			}
 		},
 		"node_modules/lilconfig": {
@@ -21356,6 +21437,13 @@
 				"node": ">=8"
 			}
 		},
+		"node_modules/pako": {
+			"version": "1.0.11",
+			"resolved": "https://registry.npmjs.org/pako/-/pako-1.0.11.tgz",
+			"integrity": "sha512-4hLB8Py4zZce5s4yd9XzopqwVv/yGNhV1Bl8NTmCq1763HeK2+EwVTv+leGeL13Dnh2wfbqowVPXCIO0z4taYw==",
+			"dev": true,
+			"license": "(MIT AND Zlib)"
+		},
 		"node_modules/param-case": {
 			"version": "3.0.4",
 			"resolved": "https://registry.npmjs.org/param-case/-/param-case-3.0.4.tgz",
@@ -22076,8 +22164,7 @@
 			"resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
 			"integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==",
 			"dev": true,
-			"license": "MIT",
-			"peer": true
+			"license": "MIT"
 		},
 		"node_modules/progress": {
 			"version": "2.0.3",
@@ -24123,6 +24210,13 @@
 			"engines": {
 				"node": ">= 0.4"
 			}
+		},
+		"node_modules/setimmediate": {
+			"version": "1.0.5",
+			"resolved": "https://registry.npmjs.org/setimmediate/-/setimmediate-1.0.5.tgz",
+			"integrity": "sha512-MATJdZp8sLqDl/68LfQmbP8zKPLQNV6BIZoIgrscFDQ+RsvK/BxeDQOgyxKKoh0y/8h3BqVFnCqQ/gd+reiIXA==",
+			"dev": true,
+			"license": "MIT"
 		},
 		"node_modules/shallow-clone": {
 			"version": "3.0.1",
@@ -26747,6 +26841,31 @@
 				"node": ">=8"
 			}
 		},
+		"node_modules/unzip-crx-3": {
+			"version": "0.2.0",
+			"resolved": "https://registry.npmjs.org/unzip-crx-3/-/unzip-crx-3-0.2.0.tgz",
+			"integrity": "sha512-0+JiUq/z7faJ6oifVB5nSwt589v1KCduqIJupNVDoWSXZtWDmjDGO3RAEOvwJ07w90aoXoP4enKsR7ecMrJtWQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"jszip": "^3.1.0",
+				"mkdirp": "^0.5.1",
+				"yaku": "^0.16.6"
+			}
+		},
+		"node_modules/unzip-crx-3/node_modules/mkdirp": {
+			"version": "0.5.6",
+			"resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.6.tgz",
+			"integrity": "sha512-FP+p8RB8OWpF3YZBCrP5gtADmtXApB5AMLn+vdyA+PyxCjrCs00mjyUozssO33cwDeT3wNGdLxJ5M//YqtHAJw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"minimist": "^1.2.6"
+			},
+			"bin": {
+				"mkdirp": "bin/cmd.js"
+			}
+		},
 		"node_modules/update-browserslist-db": {
 			"version": "1.1.1",
 			"resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.1.1.tgz",
@@ -28047,6 +28166,13 @@
 			"engines": {
 				"node": ">=10"
 			}
+		},
+		"node_modules/yaku": {
+			"version": "0.16.7",
+			"resolved": "https://registry.npmjs.org/yaku/-/yaku-0.16.7.tgz",
+			"integrity": "sha512-Syu3IB3rZvKvYk7yTiyl1bo/jiEFaaStrgv1V2TIJTqYPStSMQVO8EQjg/z+DRzLq/4LIIharNT3iH1hylEIRw==",
+			"dev": true,
+			"license": "MIT"
 		},
 		"node_modules/yallist": {
 			"version": "3.1.1",

--- a/package.json
+++ b/package.json
@@ -88,6 +88,7 @@
 		"@lexical/react": "^0.19.0",
 		"@popperjs/core": "^2.11.8",
 		"@reduxjs/toolkit": "^2.2.7",
+		"@tanstack/react-virtual": "^3.11.2",
 		"@types/mdast": "^4.0.4",
 		"better-sqlite3": "^9.6.0",
 		"crc": "^4.3.2",

--- a/package.json
+++ b/package.json
@@ -46,6 +46,7 @@
 		"css-loader": "^6.8.1",
 		"electron": "^25.9.8",
 		"electron-builder": "^24.13.3",
+		"electron-devtools-installer": "^4.0.0",
 		"eslint": "^8.40.0",
 		"eslint-import-resolver-typescript": "^3.6.1",
 		"eslint-plugin-import": "^2.29.1",

--- a/src/components/NotePreview/NotePreview.tsx
+++ b/src/components/NotePreview/NotePreview.tsx
@@ -34,3 +34,5 @@ export const NotePreview = forwardRef<
 		</VStack>
 	);
 });
+
+NotePreview.displayName = 'NotePreview';

--- a/src/components/NotePreview/NotePreview.tsx
+++ b/src/components/NotePreview/NotePreview.tsx
@@ -10,8 +10,6 @@ export const NotePreview = forwardRef<
 		isSelected?: boolean;
 	} & StackProps
 >(({ title, text, meta, isSelected, ...props }, ref) => {
-	console.log('Render NotePreview');
-
 	const styles = useMultiStyleConfig('NotePreview');
 
 	return (

--- a/src/components/NotePreview/NotePreview.tsx
+++ b/src/components/NotePreview/NotePreview.tsx
@@ -1,18 +1,22 @@
-import React, { FC, ReactNode } from 'react';
+import React, { forwardRef, ReactNode } from 'react';
 import { Box, StackProps, Text, useMultiStyleConfig, VStack } from '@chakra-ui/react';
 
-export const NotePreview: FC<
+export const NotePreview = forwardRef<
+	HTMLDivElement,
 	{
 		title: string;
 		text: string;
 		meta?: ReactNode;
 		isSelected?: boolean;
 	} & StackProps
-> = ({ title, text, meta, isSelected, ...props }) => {
+>(({ title, text, meta, isSelected, ...props }, ref) => {
+	console.log('Render NotePreview');
+
 	const styles = useMultiStyleConfig('NotePreview');
 
 	return (
 		<VStack
+			ref={ref}
 			aria-selected={isSelected}
 			{...props}
 			sx={{
@@ -31,4 +35,4 @@ export const NotePreview: FC<
 			{meta && <Box sx={styles.meta}>{meta}</Box>}
 		</VStack>
 	);
-};
+});

--- a/src/features/App/Profile/index.tsx
+++ b/src/features/App/Profile/index.tsx
@@ -37,8 +37,6 @@ export const Profile: FC<ProfileProps> = ({ profile: currentProfile, controls })
 		isEqual,
 	);
 
-	console.log('> RENDER Profile');
-
 	const workspacesManager = useMemo(
 		() => new WorkspacesController(currentProfile.db),
 		[currentProfile.db],

--- a/src/features/App/Profile/index.tsx
+++ b/src/features/App/Profile/index.tsx
@@ -37,6 +37,8 @@ export const Profile: FC<ProfileProps> = ({ profile: currentProfile, controls })
 		isEqual,
 	);
 
+	console.log('> RENDER Profile');
+
 	const workspacesManager = useMemo(
 		() => new WorkspacesController(currentProfile.db),
 		[currentProfile.db],

--- a/src/features/App/Profiles/index.tsx
+++ b/src/features/App/Profiles/index.tsx
@@ -10,6 +10,7 @@ export type ProfilesProps = {
 };
 
 export const Profiles: FC<ProfilesProps> = ({ profilesApi }) => {
+	console.log('> RENDER Profiles');
 	const dispatch = useAppDispatch();
 	return (
 		<>

--- a/src/features/App/Profiles/index.tsx
+++ b/src/features/App/Profiles/index.tsx
@@ -10,7 +10,6 @@ export type ProfilesProps = {
 };
 
 export const Profiles: FC<ProfilesProps> = ({ profilesApi }) => {
-	console.log('> RENDER Profiles');
 	const dispatch = useAppDispatch();
 	return (
 		<>

--- a/src/features/App/Profiles/index.tsx
+++ b/src/features/App/Profiles/index.tsx
@@ -35,7 +35,10 @@ export const Profiles: FC<ProfilesProps> = ({ profilesApi }) => {
 				};
 
 				return (
-					<ProfileControlsContext.Provider value={controls}>
+					<ProfileControlsContext.Provider
+						value={controls}
+						key={profile.profile.id}
+					>
 						<Profile profile={profile} controls={controls} />
 					</ProfileControlsContext.Provider>
 				);

--- a/src/features/App/Workspace/WorkspaceStatusBarItems.tsx
+++ b/src/features/App/Workspace/WorkspaceStatusBarItems.tsx
@@ -4,6 +4,7 @@ import { useStatusBarManager } from '@features/MainScreen/StatusBar/StatusBarPro
 import { useFirstRender } from '@hooks/useFirstRender';
 
 import { useProfileControls } from '../Profile';
+import { useActiveNoteHistoryButton } from './useActiveNoteHistoryButton';
 
 export const WorkspaceStatusBarItems = () => {
 	const statusBarButtons = useStatusBarManager();
@@ -37,6 +38,8 @@ export const WorkspaceStatusBarItems = () => {
 			},
 		);
 	});
+
+	useActiveNoteHistoryButton();
 
 	return null;
 };

--- a/src/features/App/Workspace/index.tsx
+++ b/src/features/App/Workspace/index.tsx
@@ -37,8 +37,6 @@ export const Workspace: FC<WorkspaceProps> = ({ profile }) => {
 	const dispatch = useAppDispatch();
 	const workspaceData = useWorkspaceData();
 
-	console.log('> RENDER Workspace');
-
 	const { name: workspaceName } = useWorkspaceSelector(selectWorkspaceName);
 
 	// Close notes by unmount

--- a/src/features/App/Workspace/index.tsx
+++ b/src/features/App/Workspace/index.tsx
@@ -14,7 +14,6 @@ import {
 } from '@state/redux/profiles/profiles';
 import { createContextGetterHook } from '@utils/react/createContextGetterHook';
 
-import { useProfileSyncButton } from '../Profile/ProfileStatusBar/useProfileSyncButton';
 import { ProfileContainer } from '../Profiles/hooks/useProfileContainers';
 import { useWorkspace } from './useWorkspace';
 import { WorkspaceProvider } from './WorkspaceProvider';
@@ -38,7 +37,7 @@ export const Workspace: FC<WorkspaceProps> = ({ profile }) => {
 	const dispatch = useAppDispatch();
 	const workspaceData = useWorkspaceData();
 
-	useProfileSyncButton();
+	console.log('> RENDER Workspace');
 
 	const { name: workspaceName } = useWorkspaceSelector(selectWorkspaceName);
 

--- a/src/features/App/Workspace/useActiveNoteHistoryButton.tsx
+++ b/src/features/App/Workspace/useActiveNoteHistoryButton.tsx
@@ -1,0 +1,41 @@
+import React, { useEffect } from 'react';
+import { FaClockRotateLeft } from 'react-icons/fa6';
+import { useStatusBarManager } from '@features/MainScreen/StatusBar/StatusBarProvider';
+import { useWorkspaceSelector } from '@state/redux/profiles/hooks';
+import { selectActiveNoteId, selectOpenedNotes } from '@state/redux/profiles/profiles';
+
+export const useActiveNoteHistoryButton = () => {
+	const activeNoteId = useWorkspaceSelector(selectActiveNoteId);
+	const openedNotes = useWorkspaceSelector(selectOpenedNotes);
+
+	// Note items on status bar
+	const statusBarButtons = useStatusBarManager();
+	useEffect(() => {
+		const note =
+			activeNoteId !== null && openedNotes.find((note) => note.id === activeNoteId);
+		if (!note) return;
+
+		const noteDate = note.updatedTimestamp
+			? new Date(note.updatedTimestamp).toLocaleDateString()
+			: null;
+
+		statusBarButtons.controls.register(
+			'noteTime',
+			{
+				visible: noteDate !== null,
+				title: 'History',
+				icon: <FaClockRotateLeft />,
+				text: noteDate ?? '',
+				onClick: () => console.log('TODO: show note history'),
+			},
+			{
+				placement: 'end',
+				priority: 1000,
+			},
+		);
+
+		return () => {
+			statusBarButtons.controls.unregister('noteTime');
+		};
+	}, [activeNoteId, statusBarButtons.controls, openedNotes]);
+};

--- a/src/features/MainScreen/NewNoteButton.tsx
+++ b/src/features/MainScreen/NewNoteButton.tsx
@@ -1,0 +1,18 @@
+import React from 'react';
+import { FaPenToSquare } from 'react-icons/fa6';
+import { useDebouncedCallback } from 'use-debounce';
+import { Button, HStack, Text } from '@chakra-ui/react';
+import { useCreateNote } from '@hooks/notes/useCreateNote';
+
+export const NewNoteButton = () => {
+	const createNote = useDebouncedCallback(useCreateNote(), 30);
+
+	return (
+		<Button variant="primary" w="100%" flexShrink={0} onClick={createNote}>
+			<HStack gap="1rem">
+				<FaPenToSquare />
+				<Text>New note</Text>
+			</HStack>
+		</Button>
+	);
+};

--- a/src/features/MainScreen/Notes/index.tsx
+++ b/src/features/MainScreen/Notes/index.tsx
@@ -1,7 +1,8 @@
-import React, { FC, useMemo, useRef } from 'react';
+import React, { FC, useMemo } from 'react';
 import { isEqual } from 'lodash';
 import { Box } from '@chakra-ui/react';
 import { INote, INoteContent, NoteId } from '@core/features/notes';
+import { useAsRef } from '@hooks/useAsRef';
 
 import { useEditorLinks } from '../../MonakoEditor/features/useEditorLinks';
 import { NoteEditor } from '../../NoteEditor';
@@ -17,9 +18,7 @@ export type NotesProps = {
 export const Notes: FC<NotesProps> = ({ notes, tabs, activeTab, updateNote }) => {
 	useEditorLinks();
 
-	const notesRef = useRef(notes);
-	notesRef.current = notes;
-
+	const notesRef = useAsRef(notes);
 	const updateHooks = useMemo(
 		() =>
 			Object.fromEntries(
@@ -43,7 +42,7 @@ export const Notes: FC<NotesProps> = ({ notes, tabs, activeTab, updateNote }) =>
 						];
 					}),
 			),
-		[tabs, updateNote],
+		[notesRef, tabs, updateNote],
 	);
 
 	return (

--- a/src/features/MainScreen/NotesList/index.tsx
+++ b/src/features/MainScreen/NotesList/index.tsx
@@ -11,6 +11,18 @@ import { useVirtualizer } from '@tanstack/react-virtual';
 
 import { useDefaultNoteContextMenu } from './NoteContextMenu/useDefaultNoteContextMenu';
 
+function isElementInViewport(node: HTMLElement) {
+	// eslint-disable-next-line spellcheck/spell-checker
+	const rect = node.getBoundingClientRect();
+
+	return (
+		rect.top >= 0 &&
+		rect.left >= 0 &&
+		rect.bottom <= (window.innerHeight || document.documentElement.clientHeight) &&
+		rect.right <= (window.innerWidth || document.documentElement.clientWidth)
+	);
+}
+
 export type NotesListProps = {};
 
 export const NotesList: FC<NotesListProps> = () => {
@@ -40,13 +52,18 @@ export const NotesList: FC<NotesListProps> = () => {
 	const items = virtualizer.getVirtualItems();
 
 	// Scroll to active note
+	const activeNoteRef = useRef<HTMLDivElement | null>(null);
 	useEffect(() => {
 		if (!activeNoteId) return;
+
+		// Skip if active note is in viewport
+		if (activeNoteRef.current !== null && isElementInViewport(activeNoteRef.current))
+			return;
 
 		const noteIndex = notes.findIndex((note) => note.id === activeNoteId);
 		if (noteIndex === -1) return;
 
-		virtualizer.scrollToIndex(noteIndex, { align: 'center' });
+		virtualizer.scrollToIndex(noteIndex, { align: 'start' });
 
 		// We only need scroll to active note once by its change
 		// eslint-disable-next-line react-hooks/exhaustive-deps
@@ -93,15 +110,22 @@ export const NotesList: FC<NotesListProps> = () => {
 
 							const date = note.createdTimestamp ?? note.updatedTimestamp;
 							const text = note.content.text.slice(0, 80).trim();
+							const isActive = note.id === activeNoteId;
 
 							// TODO: get preview text from DB as prepared value
 							// TODO: show attachments
 							return (
 								<NotePreview
 									key={note.id}
-									ref={virtualizer.measureElement}
+									ref={(node) => {
+										if (isActive) {
+											activeNoteRef.current = node;
+										}
+
+										virtualizer.measureElement(node);
+									}}
 									data-index={virtualRow.index}
-									isSelected={note.id === activeNoteId}
+									isSelected={isActive}
 									title={getNoteTitle(note.content)}
 									text={text}
 									meta={

--- a/src/features/MainScreen/NotesList/index.tsx
+++ b/src/features/MainScreen/NotesList/index.tsx
@@ -8,20 +8,9 @@ import { useUpdateNotes } from '@hooks/notes/useUpdateNotes';
 import { useWorkspaceSelector } from '@state/redux/profiles/hooks';
 import { selectActiveNoteId, selectNotes } from '@state/redux/profiles/profiles';
 import { useVirtualizer } from '@tanstack/react-virtual';
+import { isElementInViewport } from '@utils/dom/isElementInViewport';
 
 import { useDefaultNoteContextMenu } from './NoteContextMenu/useDefaultNoteContextMenu';
-
-function isElementInViewport(node: HTMLElement) {
-	// eslint-disable-next-line spellcheck/spell-checker
-	const rect = node.getBoundingClientRect();
-
-	return (
-		rect.top >= 0 &&
-		rect.left >= 0 &&
-		rect.bottom <= (window.innerHeight || document.documentElement.clientHeight) &&
-		rect.right <= (window.innerWidth || document.documentElement.clientWidth)
-	);
-}
 
 export type NotesListProps = {};
 

--- a/src/features/MainScreen/NotesList/index.tsx
+++ b/src/features/MainScreen/NotesList/index.tsx
@@ -1,5 +1,5 @@
-import React, { FC } from 'react';
-import { Text, VStack } from '@chakra-ui/react';
+import React, { FC, useEffect, useRef } from 'react';
+import { Box, Text, VStack } from '@chakra-ui/react';
 import { NotePreview } from '@components/NotePreview/NotePreview';
 import { getNoteTitle } from '@core/features/notes/utils';
 import { useNotesRegistry } from '@features/App/Workspace/WorkspaceProvider';
@@ -7,12 +7,15 @@ import { useNoteActions } from '@hooks/notes/useNoteActions';
 import { useUpdateNotes } from '@hooks/notes/useUpdateNotes';
 import { useWorkspaceSelector } from '@state/redux/profiles/hooks';
 import { selectActiveNoteId, selectNotes } from '@state/redux/profiles/profiles';
+import { useVirtualizer } from '@tanstack/react-virtual';
 
 import { useDefaultNoteContextMenu } from './NoteContextMenu/useDefaultNoteContextMenu';
 
 export type NotesListProps = {};
 
 export const NotesList: FC<NotesListProps> = () => {
+	console.log('> Render NotesList');
+
 	const notesRegistry = useNotesRegistry();
 	const updateNotes = useUpdateNotes();
 	const noteActions = useNoteActions();
@@ -26,9 +29,33 @@ export const NotesList: FC<NotesListProps> = () => {
 		updateNotes,
 	});
 
+	const parentRef = useRef<HTMLDivElement>(null);
+	const virtualizer = useVirtualizer({
+		count: notes.length,
+		getScrollElement: () => parentRef.current,
+		estimateSize: () => 200,
+		overscan: 5,
+	});
+
+	const items = virtualizer.getVirtualItems();
+
+	// Scroll to active note
+	useEffect(() => {
+		if (!activeNoteId) return;
+
+		const noteIndex = notes.findIndex((note) => note.id === activeNoteId);
+		if (noteIndex === -1) return;
+
+		virtualizer.scrollToIndex(noteIndex, { align: 'center' });
+
+		// We only need scroll to active note once by its change
+		// eslint-disable-next-line react-hooks/exhaustive-deps
+	}, [activeNoteId]);
+
 	// TODO: implement dragging and moving items
 	return (
 		<VStack
+			ref={parentRef}
 			sx={{
 				w: '100%',
 				h: '100%',
@@ -42,41 +69,59 @@ export const NotesList: FC<NotesListProps> = () => {
 					Nothing added yet
 				</Text>
 			) : (
-				<VStack
+				<Box
 					sx={{
-						w: '100%',
-						align: 'start',
-						gap: '4px',
+						display: 'block',
+						position: 'relative',
+						width: '100%',
+						height: virtualizer.getTotalSize(),
+						flexShrink: 0,
 					}}
 				>
-					{notes.map((note) => {
-						const date = note.createdTimestamp ?? note.updatedTimestamp;
-						const text = note.content.text.slice(0, 80).trim();
+					<VStack
+						sx={{
+							position: 'absolute',
+							width: '100%',
+							top: 0,
+							left: 0,
+							transform: `translateY(${items[0]?.start ?? 0}px)`,
+						}}
+					>
+						{virtualizer.getVirtualItems().map((virtualRow) => {
+							const note = notes[virtualRow.index];
 
-						// TODO: get preview text from DB as prepared value
-						// TODO: show attachments
-						return (
-							<NotePreview
-								key={note.id}
-								isSelected={note.id === activeNoteId}
-								title={getNoteTitle(note.content)}
-								text={text}
-								meta={
-									date && <Text>{new Date(date).toDateString()}</Text>
-								}
-								onContextMenu={(evt) => {
-									openNoteContextMenu(note.id, {
-										x: evt.pageX,
-										y: evt.pageY,
-									});
-								}}
-								onClick={() => {
-									noteActions.click(note.id);
-								}}
-							/>
-						);
-					})}
-				</VStack>
+							const date = note.createdTimestamp ?? note.updatedTimestamp;
+							const text = note.content.text.slice(0, 80).trim();
+
+							// TODO: get preview text from DB as prepared value
+							// TODO: show attachments
+							return (
+								<NotePreview
+									key={note.id}
+									ref={virtualizer.measureElement}
+									data-index={virtualRow.index}
+									isSelected={note.id === activeNoteId}
+									title={getNoteTitle(note.content)}
+									text={text}
+									meta={
+										date && (
+											<Text>{new Date(date).toDateString()}</Text>
+										)
+									}
+									onContextMenu={(evt) => {
+										openNoteContextMenu(note.id, {
+											x: evt.pageX,
+											y: evt.pageY,
+										});
+									}}
+									onClick={() => {
+										noteActions.click(note.id);
+									}}
+								/>
+							);
+						})}
+					</VStack>
+				</Box>
 			)}
 		</VStack>
 	);

--- a/src/features/MainScreen/NotesList/index.tsx
+++ b/src/features/MainScreen/NotesList/index.tsx
@@ -33,7 +33,7 @@ export const NotesList: FC<NotesListProps> = () => {
 	const virtualizer = useVirtualizer({
 		count: notes.length,
 		getScrollElement: () => parentRef.current,
-		estimateSize: () => 200,
+		estimateSize: () => 70,
 		overscan: 5,
 	});
 
@@ -85,6 +85,7 @@ export const NotesList: FC<NotesListProps> = () => {
 							top: 0,
 							left: 0,
 							transform: `translateY(${items[0]?.start ?? 0}px)`,
+							gap: '4px',
 						}}
 					>
 						{virtualizer.getVirtualItems().map((virtualRow) => {

--- a/src/features/MainScreen/NotesList/index.tsx
+++ b/src/features/MainScreen/NotesList/index.tsx
@@ -15,8 +15,6 @@ import { useDefaultNoteContextMenu } from './NoteContextMenu/useDefaultNoteConte
 export type NotesListProps = {};
 
 export const NotesList: FC<NotesListProps> = () => {
-	console.log('> Render NotesList');
-
 	const notesRegistry = useNotesRegistry();
 	const updateNotes = useUpdateNotes();
 	const noteActions = useNoteActions();

--- a/src/features/MainScreen/NotesOverview/index.tsx
+++ b/src/features/MainScreen/NotesOverview/index.tsx
@@ -209,8 +209,6 @@ export const NotesOverview: FC<NotesOverviewProps> = () => {
 								setIsAddTagPopupOpened(true);
 							},
 							async onDelete(id) {
-								console.log('Delete tag', id);
-
 								const tag = tags.find((tag) => id === tag.id);
 								if (!tag) return;
 
@@ -222,8 +220,6 @@ export const NotesOverview: FC<NotesOverviewProps> = () => {
 								await tagsRegistry.delete(id);
 							},
 							onEdit(id) {
-								console.log('Edit tag', id);
-
 								const tag = tags.find((tag) => id === tag.id);
 
 								if (!tag) return;

--- a/src/features/MainScreen/TopBar/index.tsx
+++ b/src/features/MainScreen/TopBar/index.tsx
@@ -64,11 +64,11 @@ export const TopBar: FC<TopBarProps> = ({
 			bgColor="surface.panel"
 		>
 			<TabList
+				display="flex"
 				flexWrap="wrap"
+				overflow="hidden"
 				borderBottom="1px solid"
 				borderColor="surface.border"
-				display="grid"
-				gridTemplateColumns="repeat(auto-fit, minmax(150px, 1fr))"
 			>
 				{existsTabs.map((noteId, index) => {
 					const isActiveTab = index === tabIndex;
@@ -90,6 +90,9 @@ export const TopBar: FC<TopBarProps> = ({
 							fontWeight="600"
 							fontSize="14"
 							maxW="250px"
+							minW="150px"
+							whiteSpace="nowrap"
+							flex="1 1 auto"
 							marginBottom={0}
 							title={title}
 							onMouseDown={(evt) => {

--- a/src/features/MainScreen/index.tsx
+++ b/src/features/MainScreen/index.tsx
@@ -16,8 +16,6 @@ export const MainScreen: FC = () => {
 	const tagsRegistry = useTagsRegistry();
 	const updateNotes = useUpdateNotes();
 
-	console.log('> RENDER MainScreen');
-
 	// Init notes list
 	useEffect(() => {
 		updateNotes();

--- a/src/features/MainScreen/index.tsx
+++ b/src/features/MainScreen/index.tsx
@@ -1,27 +1,29 @@
 import React, { FC, useEffect } from 'react';
-import { FaClockRotateLeft, FaPenToSquare } from 'react-icons/fa6';
-import { Button, HStack, Text, VStack } from '@chakra-ui/react';
+import { HStack, VStack } from '@chakra-ui/react';
 import { useTagsRegistry } from '@features/App/Workspace/WorkspaceProvider';
 import { NotesPanel } from '@features/MainScreen/NotesPanel';
-import { useStatusBarManager } from '@features/MainScreen/StatusBar/StatusBarProvider';
 import { WorkspaceBar } from '@features/MainScreen/WorkspaceBar';
 import { NotesContainer } from '@features/NotesContainer';
-import { useCreateNote } from '@hooks/notes/useCreateNote';
 import { useUpdateNotes } from '@hooks/notes/useUpdateNotes';
-import { useWorkspaceSelector } from '@state/redux/profiles/hooks';
-import { selectActiveNoteId, selectOpenedNotes } from '@state/redux/profiles/profiles';
 
 import { ProfileSettings } from '../ProfileSettings/ProfileSettings';
+import { NewNoteButton } from './NewNoteButton';
 import { NotesOverview } from './NotesOverview';
 import { NotificationsPopup } from './NotificationsPopup/NotificationsPopup';
 import { StatusBar } from './StatusBar';
 
 export const MainScreen: FC = () => {
-	const activeNoteId = useWorkspaceSelector(selectActiveNoteId);
-
 	const tagsRegistry = useTagsRegistry();
 	const updateNotes = useUpdateNotes();
 
+	console.log('> RENDER MainScreen');
+
+	// Init notes list
+	useEffect(() => {
+		updateNotes();
+	}, [updateNotes]);
+
+	// Update notes list by attach tags
 	useEffect(() => {
 		return tagsRegistry.onChange((scope) => {
 			if (scope === 'noteTags') {
@@ -29,46 +31,6 @@ export const MainScreen: FC = () => {
 			}
 		});
 	}, [tagsRegistry, updateNotes]);
-
-	// Init
-	useEffect(() => {
-		updateNotes();
-	}, [updateNotes]);
-
-	const openedNotes = useWorkspaceSelector(selectOpenedNotes);
-
-	const createNote = useCreateNote();
-
-	// Note items on status bar
-	const statusBarButtons = useStatusBarManager();
-	useEffect(() => {
-		const note =
-			activeNoteId !== null && openedNotes.find((note) => note.id === activeNoteId);
-		if (!note) return;
-
-		const noteDate = note.updatedTimestamp
-			? new Date(note.updatedTimestamp).toLocaleDateString()
-			: null;
-
-		statusBarButtons.controls.register(
-			'noteTime',
-			{
-				visible: noteDate !== null,
-				title: 'History',
-				icon: <FaClockRotateLeft />,
-				text: noteDate ?? '',
-				onClick: () => console.log('TODO: show note history'),
-			},
-			{
-				placement: 'end',
-				priority: 1000,
-			},
-		);
-
-		return () => {
-			statusBarButtons.controls.unregister('noteTime');
-		};
-	}, [activeNoteId, statusBarButtons.controls, openedNotes]);
 
 	return (
 		<VStack gap={0} w="100%" h="100%">
@@ -102,17 +64,7 @@ export const MainScreen: FC = () => {
 						borderColor: 'surface.border',
 					}}
 				>
-					<Button
-						variant="primary"
-						w="100%"
-						flexShrink={0}
-						onClick={createNote}
-					>
-						<HStack gap="1rem">
-							<FaPenToSquare />
-							<Text>New note</Text>
-						</HStack>
-					</Button>
+					<NewNoteButton />
 
 					<NotesOverview />
 

--- a/src/features/NoteEditor/EditorPanel/EditorPanel.tsx
+++ b/src/features/NoteEditor/EditorPanel/EditorPanel.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { memo } from 'react';
 import {
 	FaBold,
 	FaCalendarDay,
@@ -21,7 +21,7 @@ import { useEditorPanelContext } from '.';
 
 // TODO: add hotkeys to trigger panel commands
 // TODO: implement notifications from editor to panel, to render current state for formatting buttons
-export const EditorPanel = () => {
+export const EditorPanel = memo(() => {
 	const { onInserting, onFormatting } = useEditorPanelContext();
 
 	return (
@@ -200,4 +200,6 @@ export const EditorPanel = () => {
 			</HStack>
 		</HStack>
 	);
-};
+});
+
+EditorPanel.displayName = 'EditorPanel';

--- a/src/features/NoteEditor/NoteMenuItems.tsx
+++ b/src/features/NoteEditor/NoteMenuItems.tsx
@@ -1,0 +1,116 @@
+import React, { memo } from 'react';
+import {
+	FaBell,
+	FaBoxArchive,
+	FaClock,
+	FaCopy,
+	FaDownload,
+	FaEllipsis,
+	FaEye,
+	FaFileExport,
+	FaLink,
+	FaRotate,
+	FaShield,
+	FaSpellCheck,
+	FaTrashCan,
+} from 'react-icons/fa6';
+import {
+	Button,
+	HStack,
+	Menu,
+	MenuButton,
+	MenuItem,
+	MenuList,
+	Text,
+} from '@chakra-ui/react';
+
+export enum NoteMenuItems {
+	TOGGLE_BACKLINKS,
+}
+
+export const NoteMenu = memo(
+	({ onClick }: { onClick?: (command: NoteMenuItems) => void }) => {
+		return (
+			<Menu>
+				<MenuButton as={Button} variant="primary" size="sm">
+					<FaEllipsis />
+				</MenuButton>
+				<MenuList>
+					<MenuItem>
+						<HStack>
+							<FaCopy />
+							<Text>Copy reference on note</Text>
+						</HStack>
+					</MenuItem>
+					<MenuItem>
+						<HStack>
+							<FaBell />
+							<Text>Remind me</Text>
+						</HStack>
+					</MenuItem>
+					<MenuItem>
+						<HStack>
+							<FaClock />
+							<Text>History</Text>
+						</HStack>
+					</MenuItem>
+					<MenuItem onClick={() => onClick?.(NoteMenuItems.TOGGLE_BACKLINKS)}>
+						<HStack>
+							<FaLink />
+							<Text>Back links</Text>
+						</HStack>
+					</MenuItem>
+					<MenuItem>
+						<HStack>
+							<FaEye />
+							<Text>Readonly mode</Text>
+						</HStack>
+					</MenuItem>
+					<MenuItem>
+						<HStack>
+							<FaDownload />
+							<Text>Download and convert a network media</Text>
+						</HStack>
+					</MenuItem>
+					<MenuItem>
+						<HStack>
+							<FaSpellCheck />
+							<Text>Spellcheck</Text>
+						</HStack>
+					</MenuItem>
+
+					<MenuItem>
+						<HStack>
+							<FaFileExport />
+							<Text>Export...</Text>
+						</HStack>
+					</MenuItem>
+					<MenuItem>
+						<HStack>
+							<FaShield />
+							<Text>Password protection...</Text>
+						</HStack>
+					</MenuItem>
+					<MenuItem>
+						<HStack>
+							<FaRotate />
+							<Text>Disable sync</Text>
+						</HStack>
+					</MenuItem>
+					<MenuItem>
+						<HStack>
+							<FaBoxArchive />
+							<Text>Archive</Text>
+						</HStack>
+					</MenuItem>
+					<MenuItem>
+						<HStack>
+							<FaTrashCan />
+							<Text>Delete</Text>
+						</HStack>
+					</MenuItem>
+				</MenuList>
+			</Menu>
+		);
+	},
+);

--- a/src/features/NoteEditor/RichEditor/RichEditor.tsx
+++ b/src/features/NoteEditor/RichEditor/RichEditor.tsx
@@ -1,5 +1,5 @@
 /* eslint-disable spellcheck/spell-checker */
-import React from 'react';
+import React, { memo } from 'react';
 import { CodeHighlightNode, CodeNode } from '@lexical/code';
 import { AutoLinkNode, LinkNode } from '@lexical/link';
 import { ListItemNode, ListNode } from '@lexical/list';
@@ -20,7 +20,7 @@ import { theme } from './theme/RichEditor';
 // TODO: support videos
 // TODO: copy markdown text by selection, not rich text
 // TODO: when user start remove markdown element - transform it to markdown and remove single char instead
-export const RichEditor = (props: RichEditorContentProps) => {
+export const RichEditor = memo((props: RichEditorContentProps) => {
 	return (
 		<LexicalComposer
 			initialConfig={{
@@ -59,4 +59,6 @@ export const RichEditor = (props: RichEditorContentProps) => {
 			<RichEditorContent {...props} />
 		</LexicalComposer>
 	);
-};
+});
+
+RichEditor.displayName = 'RichEditor';

--- a/src/features/NoteEditor/index.tsx
+++ b/src/features/NoteEditor/index.tsx
@@ -1,38 +1,7 @@
 import React, { FC, memo, useCallback, useEffect, useRef, useState } from 'react';
-import {
-	FaBell,
-	FaBookmark,
-	FaBoxArchive,
-	FaClock,
-	FaCopy,
-	FaDownload,
-	FaEllipsis,
-	FaEye,
-	FaFileExport,
-	FaFlag,
-	FaHashtag,
-	FaLink,
-	FaRotate,
-	FaShield,
-	FaSpellCheck,
-	FaTrashCan,
-	FaXmark,
-} from 'react-icons/fa6';
+import { FaBookmark, FaFlag, FaHashtag, FaXmark } from 'react-icons/fa6';
 import { debounce } from 'lodash';
-import {
-	Box,
-	Button,
-	Divider,
-	HStack,
-	Input,
-	Menu,
-	MenuButton,
-	MenuItem,
-	MenuList,
-	Tag,
-	Text,
-	VStack,
-} from '@chakra-ui/react';
+import { Box, Button, Divider, HStack, Input, Tag, Text, VStack } from '@chakra-ui/react';
 import { SuggestedTagsList } from '@components/SuggestedTagsList';
 import { findLinksInText, getResourceIdInUrl } from '@core/features/links';
 import { INote, INoteContent } from '@core/features/notes';
@@ -51,103 +20,13 @@ import { FileUploader } from '../MonakoEditor/features/useDropFiles';
 import { MonacoEditor } from '../MonakoEditor/MonacoEditor';
 import { EditorPanelContext } from './EditorPanel';
 import { EditorPanel } from './EditorPanel/EditorPanel';
+import { NoteMenu, NoteMenuItems } from './NoteMenuItems';
 import { RichEditor } from './RichEditor/RichEditor';
 
 export type NoteEditorProps = {
 	note: INote;
 	updateNote: (note: INoteContent) => void;
 };
-
-export enum NoteMenuItems {
-	TOGGLE_BACKLINKS,
-}
-
-export const NoteMenu = memo(
-	({ onClick }: { onClick?: (command: NoteMenuItems) => void }) => {
-		return (
-			<Menu>
-				<MenuButton as={Button} variant="primary" size="sm">
-					<FaEllipsis />
-				</MenuButton>
-				<MenuList>
-					<MenuItem>
-						<HStack>
-							<FaCopy />
-							<Text>Copy reference on note</Text>
-						</HStack>
-					</MenuItem>
-					<MenuItem>
-						<HStack>
-							<FaBell />
-							<Text>Remind me</Text>
-						</HStack>
-					</MenuItem>
-					<MenuItem>
-						<HStack>
-							<FaClock />
-							<Text>History</Text>
-						</HStack>
-					</MenuItem>
-					<MenuItem onClick={() => onClick?.(NoteMenuItems.TOGGLE_BACKLINKS)}>
-						<HStack>
-							<FaLink />
-							<Text>Back links</Text>
-						</HStack>
-					</MenuItem>
-					<MenuItem>
-						<HStack>
-							<FaEye />
-							<Text>Readonly mode</Text>
-						</HStack>
-					</MenuItem>
-					<MenuItem>
-						<HStack>
-							<FaDownload />
-							<Text>Download and convert a network media</Text>
-						</HStack>
-					</MenuItem>
-					<MenuItem>
-						<HStack>
-							<FaSpellCheck />
-							<Text>Spellcheck</Text>
-						</HStack>
-					</MenuItem>
-
-					<MenuItem>
-						<HStack>
-							<FaFileExport />
-							<Text>Export...</Text>
-						</HStack>
-					</MenuItem>
-					<MenuItem>
-						<HStack>
-							<FaShield />
-							<Text>Password protection...</Text>
-						</HStack>
-					</MenuItem>
-					<MenuItem>
-						<HStack>
-							<FaRotate />
-							<Text>Disable sync</Text>
-						</HStack>
-					</MenuItem>
-					<MenuItem>
-						<HStack>
-							<FaBoxArchive />
-							<Text>Archive</Text>
-						</HStack>
-					</MenuItem>
-					<MenuItem>
-						<HStack>
-							<FaTrashCan />
-							<Text>Delete</Text>
-						</HStack>
-					</MenuItem>
-				</MenuList>
-			</Menu>
-		);
-	},
-);
 
 export const NoteEditor: FC<NoteEditorProps> = memo(({ note, updateNote }) => {
 	const dispatch = useAppDispatch();

--- a/src/features/NoteEditor/index.tsx
+++ b/src/features/NoteEditor/index.tsx
@@ -1,4 +1,4 @@
-import React, { FC, useCallback, useEffect, useRef, useState } from 'react';
+import React, { FC, memo, useCallback, useEffect, useRef, useState } from 'react';
 import {
 	FaBell,
 	FaBookmark,
@@ -58,7 +58,98 @@ export type NoteEditorProps = {
 	updateNote: (note: INoteContent) => void;
 };
 
-export const NoteEditor: FC<NoteEditorProps> = ({ note, updateNote }) => {
+export enum NoteMenuItems {
+	TOGGLE_BACKLINKS,
+}
+
+export const NoteMenu = memo(
+	({ onClick }: { onClick?: (command: NoteMenuItems) => void }) => {
+		return (
+			<Menu>
+				<MenuButton as={Button} variant="primary" size="sm">
+					<FaEllipsis />
+				</MenuButton>
+				<MenuList>
+					<MenuItem>
+						<HStack>
+							<FaCopy />
+							<Text>Copy reference on note</Text>
+						</HStack>
+					</MenuItem>
+					<MenuItem>
+						<HStack>
+							<FaBell />
+							<Text>Remind me</Text>
+						</HStack>
+					</MenuItem>
+					<MenuItem>
+						<HStack>
+							<FaClock />
+							<Text>History</Text>
+						</HStack>
+					</MenuItem>
+					<MenuItem onClick={() => onClick?.(NoteMenuItems.TOGGLE_BACKLINKS)}>
+						<HStack>
+							<FaLink />
+							<Text>Back links</Text>
+						</HStack>
+					</MenuItem>
+					<MenuItem>
+						<HStack>
+							<FaEye />
+							<Text>Readonly mode</Text>
+						</HStack>
+					</MenuItem>
+					<MenuItem>
+						<HStack>
+							<FaDownload />
+							<Text>Download and convert a network media</Text>
+						</HStack>
+					</MenuItem>
+					<MenuItem>
+						<HStack>
+							<FaSpellCheck />
+							<Text>Spellcheck</Text>
+						</HStack>
+					</MenuItem>
+
+					<MenuItem>
+						<HStack>
+							<FaFileExport />
+							<Text>Export...</Text>
+						</HStack>
+					</MenuItem>
+					<MenuItem>
+						<HStack>
+							<FaShield />
+							<Text>Password protection...</Text>
+						</HStack>
+					</MenuItem>
+					<MenuItem>
+						<HStack>
+							<FaRotate />
+							<Text>Disable sync</Text>
+						</HStack>
+					</MenuItem>
+					<MenuItem>
+						<HStack>
+							<FaBoxArchive />
+							<Text>Archive</Text>
+						</HStack>
+					</MenuItem>
+					<MenuItem>
+						<HStack>
+							<FaTrashCan />
+							<Text>Delete</Text>
+						</HStack>
+					</MenuItem>
+				</MenuList>
+			</Menu>
+		);
+	},
+);
+
+export const NoteEditor: FC<NoteEditorProps> = memo(({ note, updateNote }) => {
 	const dispatch = useAppDispatch();
 	const workspaceData = useWorkspaceData();
 
@@ -151,6 +242,17 @@ export const NoteEditor: FC<NoteEditorProps> = ({ note, updateNote }) => {
 
 	const [sidePanel, setSidePanel] = useState<string | null>(null);
 
+	const onNoteMenuClick = useCallback((command: NoteMenuItems) => {
+		switch (command) {
+			case NoteMenuItems.TOGGLE_BACKLINKS:
+				setSidePanel((state) => (state ? null : 'backlinks'));
+				break;
+
+			default:
+				break;
+		}
+	}, []);
+
 	return (
 		<VStack w="100%" align="start">
 			<HStack w="100%" align="start">
@@ -164,86 +266,7 @@ export const NoteEditor: FC<NoteEditorProps> = ({ note, updateNote }) => {
 					/>
 
 					{/* TODO: add options that may be toggled */}
-					<Menu>
-						<MenuButton as={Button} variant="primary" size="sm">
-							<FaEllipsis />
-						</MenuButton>
-						<MenuList>
-							<MenuItem>
-								<HStack>
-									<FaCopy />
-									<Text>Copy reference on note</Text>
-								</HStack>
-							</MenuItem>
-							<MenuItem>
-								<HStack>
-									<FaBell />
-									<Text>Remind me</Text>
-								</HStack>
-							</MenuItem>
-							<MenuItem>
-								<HStack>
-									<FaClock />
-									<Text>History</Text>
-								</HStack>
-							</MenuItem>
-							<MenuItem onClick={() => setSidePanel('backlinks')}>
-								<HStack>
-									<FaLink />
-									<Text>Back links</Text>
-								</HStack>
-							</MenuItem>
-							<MenuItem>
-								<HStack>
-									<FaEye />
-									<Text>Readonly mode</Text>
-								</HStack>
-							</MenuItem>
-							<MenuItem>
-								<HStack>
-									<FaDownload />
-									<Text>Download and convert a network media</Text>
-								</HStack>
-							</MenuItem>
-							<MenuItem>
-								<HStack>
-									<FaSpellCheck />
-									<Text>Spellcheck</Text>
-								</HStack>
-							</MenuItem>
-
-							<MenuItem>
-								<HStack>
-									<FaFileExport />
-									<Text>Export...</Text>
-								</HStack>
-							</MenuItem>
-							<MenuItem>
-								<HStack>
-									<FaShield />
-									<Text>Password protection...</Text>
-								</HStack>
-							</MenuItem>
-							<MenuItem>
-								<HStack>
-									<FaRotate />
-									<Text>Disable sync</Text>
-								</HStack>
-							</MenuItem>
-							<MenuItem>
-								<HStack>
-									<FaBoxArchive />
-									<Text>Archive</Text>
-								</HStack>
-							</MenuItem>
-							<MenuItem>
-								<HStack>
-									<FaTrashCan />
-									<Text>Delete</Text>
-								</HStack>
-							</MenuItem>
-						</MenuList>
-					</Menu>
+					<NoteMenu onClick={onNoteMenuClick} />
 				</HStack>
 			</HStack>
 
@@ -437,4 +460,6 @@ export const NoteEditor: FC<NoteEditorProps> = ({ note, updateNote }) => {
 			)}
 		</VStack>
 	);
-};
+});
+
+NoteEditor.displayName = 'NoteEditor';

--- a/src/features/NotesContainer/index.tsx
+++ b/src/features/NotesContainer/index.tsx
@@ -1,4 +1,4 @@
-import React, { FC, useCallback } from 'react';
+import React, { FC } from 'react';
 import { Box, StackProps, VStack } from '@chakra-ui/react';
 import { INote } from '@core/features/notes';
 import {
@@ -9,6 +9,7 @@ import { Notes } from '@features/MainScreen/Notes';
 import { TopBar } from '@features/MainScreen/TopBar';
 import { useNoteActions } from '@hooks/notes/useNoteActions';
 import { useUpdateNotes } from '@hooks/notes/useUpdateNotes';
+import { useImmutableCallback } from '@hooks/useImmutableCallback';
 import { useWorkspaceSelector } from '@state/redux/profiles/hooks';
 import { selectActiveNoteId, selectOpenedNotes } from '@state/redux/profiles/profiles';
 import { createWorkspaceSelector } from '@state/redux/profiles/utils';
@@ -34,7 +35,7 @@ export const NotesContainer: FC<NotesContainerProps> = ({ ...props }) => {
 	);
 
 	// Simulate note update
-	const updateNote = useCallback(
+	const updateNote = useImmutableCallback(
 		async (note: INote) => {
 			noteUpdated(note);
 			await notesRegistry.update(note.id, note.content);

--- a/src/hooks/notes/useNoteActions.ts
+++ b/src/hooks/notes/useNoteActions.ts
@@ -26,11 +26,6 @@ export const useNoteActions = () => {
 			const notes = selectNotes(workspace);
 			const isNoteOpened = selectIsNoteOpened(id)(workspace);
 
-			console.log('DBG 1', {
-				isNoteOpened,
-				clickedNote: notes.find((note) => note.id === id),
-			});
-
 			if (isNoteOpened) {
 				dispatch(workspacesApi.setActiveNote({ ...workspaceData, noteId: id }));
 			} else {

--- a/src/hooks/notes/useUpdateNotes.ts
+++ b/src/hooks/notes/useUpdateNotes.ts
@@ -11,6 +11,8 @@ export const useUpdateNotes = () => {
 	const notesRegistry = useNotesRegistry();
 	const activeTag = useWorkspaceSelector(selectActiveTag);
 
+	console.log('>> useUpdateNotes');
+
 	return useCallback(async () => {
 		const tags = activeTag === null ? [] : [activeTag.id];
 		const notes = await notesRegistry.get({ limit: 10000, tags });

--- a/src/hooks/notes/useUpdateNotes.ts
+++ b/src/hooks/notes/useUpdateNotes.ts
@@ -11,8 +11,6 @@ export const useUpdateNotes = () => {
 	const notesRegistry = useNotesRegistry();
 	const activeTag = useWorkspaceSelector(selectActiveTag);
 
-	console.log('>> useUpdateNotes');
-
 	return useCallback(async () => {
 		const tags = activeTag === null ? [] : [activeTag.id];
 		const notes = await notesRegistry.get({ limit: 10000, tags });

--- a/src/hooks/useAsRef.ts
+++ b/src/hooks/useAsRef.ts
@@ -1,0 +1,17 @@
+import { useRef } from 'react';
+
+/**
+ * Always returns the latest passed value unlike `useRef`
+ */
+export const useAsRef = <T>(value: T) => {
+	const ref = useRef(value);
+	ref.current = value;
+
+	// Return readonly ref
+	return ref as {
+		/**
+		 * The current value of the ref.
+		 */
+		readonly current: T;
+	};
+};

--- a/src/hooks/useImmutableCallback.ts
+++ b/src/hooks/useImmutableCallback.ts
@@ -1,0 +1,30 @@
+import { DependencyList, useCallback, useRef } from 'react';
+
+/**
+ * Return immutable wrapper for callback
+ *
+ * You can still redefine callback while updating props, but will get same object
+ *
+ * This especial useful to create callback for event handlers who required same object to remove
+ */
+export const useImmutableCallback = <T extends (...args: any[]) => any>(
+	callback: T,
+	deps: DependencyList,
+): T => {
+	// Update callback only by deps changes
+	// eslint-disable-next-line react-hooks/exhaustive-deps
+	const actualCallback = useCallback(callback, deps);
+
+	// Write reference to actual callback
+	const callbackRef = useRef(actualCallback);
+	callbackRef.current = actualCallback;
+
+	// Return same wrapper
+	// eslint-disable-next-line react-hooks/exhaustive-deps
+	const staticCallback = useCallback(
+		((...args) => callbackRef.current(...args)) as T,
+		[],
+	);
+
+	return staticCallback;
+};

--- a/src/main.ts
+++ b/src/main.ts
@@ -10,7 +10,25 @@ console.log({
 });
 
 Menu.setApplicationMenu(null);
-app.whenReady().then(() => {
+app.whenReady().then(async () => {
 	console.log('App ready');
+
+	if (isDevMode()) {
+		console.log('Install dev tools');
+
+		const { installExtension, REACT_DEVELOPER_TOOLS, REDUX_DEVTOOLS } = await import(
+			// eslint-disable-next-line spellcheck/spell-checker
+			'electron-devtools-installer'
+		);
+
+		await Promise.all(
+			[REACT_DEVELOPER_TOOLS, REDUX_DEVTOOLS].map((extension) =>
+				installExtension(extension)
+					.then((ext) => console.log(`Added Extension:  ${ext.name}`))
+					.catch((err) => console.log('An error occurred: ', err)),
+			),
+		);
+	}
+
 	openMainWindow();
 });

--- a/src/main.ts
+++ b/src/main.ts
@@ -23,7 +23,9 @@ app.whenReady().then(async () => {
 
 		await Promise.all(
 			[REACT_DEVELOPER_TOOLS, REDUX_DEVTOOLS].map((extension) =>
-				installExtension(extension)
+				installExtension(extension, {
+					loadExtensionOptions: { allowFileAccess: true },
+				})
 					.then((ext) => console.log(`Added Extension:  ${ext.name}`))
 					.catch((err) => console.log('An error occurred: ', err)),
 			),

--- a/src/state/redux/profiles/hooks.ts
+++ b/src/state/redux/profiles/hooks.ts
@@ -1,4 +1,5 @@
 import { useMemo } from 'react';
+import { isEqual } from 'lodash';
 import { useWorkspaceContext } from '@features/App/Workspace';
 import { Selector } from '@reduxjs/toolkit';
 
@@ -24,7 +25,5 @@ export const useWorkspaceSelector = <T>(
 	selector: Selector<WorkspaceData | null, T>,
 ): T => {
 	const selectWorkspace = useWorkspaceRootSelector();
-	const state = useAppSelector(selectWorkspace);
-
-	return selector(state);
+	return useAppSelector((state) => selector(selectWorkspace(state)), isEqual);
 };

--- a/src/state/redux/profiles/selectors/notes.ts
+++ b/src/state/redux/profiles/selectors/notes.ts
@@ -23,6 +23,12 @@ export const selectOpenedNotes = createWorkspaceSelector(
 	},
 );
 
+export const selectIsNoteOpened = (noteId: string) =>
+	createWorkspaceSelector([selectWorkspaceRoot], (workspace) => {
+		if (!workspace) return false;
+		return workspace.openedNotes.some((note) => note.id === noteId);
+	});
+
 export const selectNote = (noteId: string | null) =>
 	createWorkspaceSelector([selectWorkspaceRoot], (workspace) => {
 		if (!workspace) return null;

--- a/src/utils/dom/isElementInViewport.tsx
+++ b/src/utils/dom/isElementInViewport.tsx
@@ -1,0 +1,11 @@
+export function isElementInViewport(node: HTMLElement) {
+	// eslint-disable-next-line spellcheck/spell-checker
+	const rect = node.getBoundingClientRect();
+
+	return (
+		rect.top >= 0 &&
+		rect.left >= 0 &&
+		rect.bottom <= (window.innerHeight || document.documentElement.clientHeight) &&
+		rect.right <= (window.innerWidth || document.documentElement.clientWidth)
+	);
+}

--- a/src/utils/workers/WorkerMessenger.ts
+++ b/src/utils/workers/WorkerMessenger.ts
@@ -49,7 +49,6 @@ export class WorkerMessenger {
 
 		// Send message
 		if (this.target instanceof Worker) {
-			console.log('TO', payload, transferObjects);
 			this.target.postMessage(payload, transferObjects ?? []);
 		} else {
 			this.target.postMessage(payload, {


### PR DESCRIPTION
Closes #98

# Debugging methodology

To measure performance and find problems has been used
- Manual debugging with console prints
- Profiler of React dev tool extension
- Redux dev tool extension was used to track state changes frequency

The most efficient way is an React profiler. It allow us to see what components has been rendered, how much renders is occurs, to measure rendering time and to see a reasons of re-renders.

To simplify debugging in future, a dev extensions now will installs automatically in dev mode (only there).

# Found problems

- Notes list renders too slow. Attempt to render 3k note items with trivial DOM structure is a critical for performance. Fixed with virtual scroll
- Chakra components renders too long time. As temporary workaround, performance-critical components is wrapped via `memo`

# Roadmap

- [x] Remove a space for virtual scroll
- [x] Debug updates in `useUpdateNotes`
- [x] Optimize selectors use (introduce memoizing)
- [x] Remove debug prints

# Benchmark

I've run a trivial case to measure performance.

Prerequisites:
- Create profile
- Add about 1k notes. You may spawn it with script, or just click "New note", it does not matter (it would be nice to attach an test DB later, with seed data for consistent results in future runs)
- Run application in dev mode

Steps
- Reload window
- Open 3 tabs with notes (i've opened just first 3 ones)
- In dev tools, click tab "Profiler" to open react profiler
- Click "Start profiling" to start recording
- In app, click button "New note" with mouse
- In dev tools click "Stop profiling" and then "Save profile..." and save measurements

I attach my measurements only for fixed version of code, because when i tried to measure performance for code on master, all app is just stuck for a seconds when i clicked "New note" and then dev tools go down always. So i can't measure performance of legacy code.

Subjectively i would say it takes about 10 seconds to create new note. It is absolutely unacceptable performance.

On fixed version it takes about 60ms to create a new note. There are 9 renders, and top time consumers is ones with 34ms, 19.6, 7 and 7.2.

Full **profiler dump** data is here [deepink-profiling-25.08.2025.json](https://github.com/user-attachments/files/21969366/deepink-profiling-25.08.2025.json)

To anonymize paths, i've used next sed `sed 's#file:///home/username/deepink#file:///project-dir#g'`