### PR TITLE
Rich editor does not appears after change view mode 

### DIFF
--- a/src/features/NoteEditor/index.tsx
+++ b/src/features/NoteEditor/index.tsx
@@ -133,7 +133,7 @@ export const NoteEditor: FC<NoteEditorProps> = memo(({ note, updateNote }) => {
 	}, []);
 
 	return (
-		<VStack w="100%" align="start" minW="300px">
+		<VStack w="100%" align="start">
 			<HStack w="100%" align="start">
 				<HStack w="100%" align="start">
 					<Input


### PR DESCRIPTION
#92 
Problem: When selecting "Split screen" after choosing "Plaintext", the split screen does not appear. However, in the inspector, the second editor is rendered, but it is not visible.

I found the solution here: https://github.com/microsoft/monaco-editor/issues/3393

As i understand, its works because:
- Flex items have min-width: auto by default, which for flex containers means: [min-width: min-content](developer.mozilla.org/en-US/docs/Web/CSS/min-width#values)
- When only the MonacoEditor is displayed, it takes up all the available space, and the elements are given specific widths
- When split mode is enabled, the MonacoEditor should shrink
- But the browser cannot shrink the MonacoEditor because its min-width is min-content and the content already requires a fixed width
- By setting min-width: 0, the browser ignores the minimum content width and allows to shrink the element

Result:

https://github.com/user-attachments/assets/67350565-68e9-4cb7-8a2a-c549ba796c05



