### PR TITLE
fix: filter log entries by action name

### DIFF
--- a/src/core/features/notes/controller/LexemesRegistry.ts
+++ b/src/core/features/notes/controller/LexemesRegistry.ts
@@ -41,7 +41,7 @@ export class LexemesRegistry {
 		return this.db.get().transaction(async (tx) => {
 			const db = wrapDB(tx);
 
-			const textsQuery = qb.sql`SELECT text_tsv FROM notes WHERE updated_at >= COALESCE((SELECT executed_at FROM lexeme_ops ORDER BY executed_at DESC LIMIT 1), to_timestamp(0))`;
+			const textsQuery = qb.sql`SELECT text_tsv FROM notes WHERE updated_at >= COALESCE((SELECT executed_at FROM lexeme_ops WHERE action = ''scan'' ORDER BY executed_at DESC LIMIT 1), to_timestamp(0))`;
 
 			const { rows } = await db.query(
 				qb.sql`INSERT INTO lexemes(word, query) SELECT word, plainto_tsquery('simple', word) AS query FROM ts_stat(E'${textsQuery}') ON CONFLICT DO NOTHING RETURNING word`,


### PR DESCRIPTION
Closes #147

The root cause is when a **prune** action is logged first (30 seconds ago of last edit) and before **scan** action, the **scan** action will skip notes that has updated early than **prune** was run.

The problem is I missed a filter for `lexeme_ops` table. Current PR adds a filter.

To reproduce a bug:
- Create new profile
- Add note
- Wait 30 seconds (to run prune in background)
- Try to run search

Search will be empty.