### PR TITLE
Bug: SVG images is not shown

### DIFF
--- a/src/features/NoteEditor/RichEditor/plugins/Image/ImageComponent.tsx
+++ b/src/features/NoteEditor/RichEditor/plugins/Image/ImageComponent.tsx
@@ -58,7 +58,7 @@ function useSuspenseImage(src: string) {
 					return;
 				}
 
-				actualSrc = URL.createObjectURL(new Blob([file]));
+				actualSrc = URL.createObjectURL(new Blob([file], { type: file.type }));
 			}
 
 			const img = new Image();


### PR DESCRIPTION
Closes #123 

Why the SVG is not show?

This happens because when creating a Blob from a file, the MIME type isn’t set, so the browser can’t interpret the data. Unlike JPG or PNG, which include format information in their headers, SVG files don’t have this information. Without a proper MIME type, the browser doesn’t know how to parse the SVG.

So we need to set type: "image/svg+xml"
