### PR TITLE
Bug: When closing a note, the text is pasted into the search

### DIFF
--- a/src/features/MainScreen/index.tsx
+++ b/src/features/MainScreen/index.tsx
@@ -31,20 +31,23 @@ export const MainScreen: FC = () => {
 	}, [tagsRegistry, updateNotes]);
 
 	useEffect(() => {
+		// Prevent a KDE/X11 issue where pressing the middle mouse button pastes text
+		// from the clipboard into the focused element, even when clicking another element
 		const preventTextInsert = (e: MouseEvent) => {
+			// 1 is the middle mouse button
 			if (e.button !== 1) return;
 
 			const isEditable = e.composedPath().some((element) => {
+				if (!(element instanceof HTMLElement)) return false;
+
 				return (
-					element instanceof HTMLInputElement ||
-					element instanceof HTMLTextAreaElement ||
-					(element instanceof HTMLElement && element.isContentEditable)
+					element.tagName === 'INPUT' ||
+					element.tagName === 'TEXTAREA' ||
+					element.isContentEditable
 				);
 			});
 
 			if (!isEditable) {
-				// Prevent a KDE/X11 issue where pressing the middle mouse button pastes text
-				// from the clipboard into the focused element, even when clicking another element
 				e.preventDefault();
 			}
 		};


### PR DESCRIPTION
Closes #149 

The problem is specific to X11 systems, such as KDE: clicking the middle mouse button pastes the selected text into the currently focused element, even when clicking on a different element.

**Solution:**
Prevent text from being inserted into the focused field when the middle-click occurs on another element.

We listen to the `mouseup` event because the OS performs the paste on button release. Using `mousedown` doesn’t work, and `click` is too late, as the paste has already occurred.

As a result, middle-click paste only works when the clicked element is the same as the currently focused element.