### PR TITLE
fix: infinity loop if image is not found in FS

### DIFF
--- a/src/features/NoteEditor/RichEditor/plugins/Image/ImageComponent.tsx
+++ b/src/features/NoteEditor/RichEditor/plugins/Image/ImageComponent.tsx
@@ -71,7 +71,7 @@ function useSuspenseImage(src: string) {
 			};
 			img.onerror = () => {
 				imageCache.set(src, null);
-				reject(new Error('Error while load image'));
+				reject(new Error('Failed to load image'));
 			};
 		});
 	}
@@ -262,10 +262,7 @@ export default function ImageComponent({
 						width={width}
 						height={height}
 						maxWidth={maxWidth}
-						onError={() => {
-							console.log('call');
-							setIsLoadError(true);
-						}}
+						onError={() => setIsLoadError(true)}
 						onLoad={markDirty}
 					/>
 				)}


### PR DESCRIPTION
Closes #124

**Why we have infinity loop ?**
The problem was caused by the `Suspense` component. It works like this: it renders the fallback while a child component throws a Promise. As soon as that Promise settles, a re-render happens. If during that re-render the child throws a Promise again instead of returning a value, it results in an infinite loop.

To prevent this, data is cached. The issue was that errors weren’t cached, so each render threw a Promise and caused a loop. 

I also found an additional issue: when using the `Add image` component with an external image URL, if the image failed to load the spinner would spin forever. This happened because the Promise never resolves.
