### PR TITLE
fix: tag duplicates error while notes import

### DIFF
--- a/src/core/features/tags/controller/TagsController.test.ts
+++ b/src/core/features/tags/controller/TagsController.test.ts
@@ -481,7 +481,7 @@ describe('manage attachments', () => {
 		});
 	});
 
-	test('throw error when attach duplicate tags', async () => {
+	test('does not throw error when attach duplicate tags', async () => {
 		const db = await getDB();
 		const tags = new TagsController(db, FAKE_WORKSPACE_ID);
 
@@ -492,13 +492,20 @@ describe('manage attachments', () => {
 
 		await expect(
 			tags.setAttachedTags(FAKE_NOTE_ID, [fooId, barId, fooId]),
-		).rejects.toThrow(
-			expect.objectContaining({
-				code: TAG_ERROR_CODE.DUPLICATE,
-			}),
-		);
+		).resolves.not.toThrow();
 
-		await expect(tags.getAttachedTags(FAKE_NOTE_ID)).resolves.toEqual([]);
+		await expect(tags.getAttachedTags(FAKE_NOTE_ID)).resolves.toEqual(
+			expect.arrayContaining([
+				expect.objectContaining({
+					name: 'foo',
+					resolvedName: 'foo',
+				}),
+				expect.objectContaining({
+					name: 'bar',
+					resolvedName: 'bar',
+				}),
+			]),
+		);
 	});
 
 	test('deleted tag will not appears in tags list', async () => {

--- a/src/core/features/tags/controller/TagsController.ts
+++ b/src/core/features/tags/controller/TagsController.ts
@@ -306,11 +306,7 @@ export class TagsController {
 
 	public async setAttachedTags(target: string, tags: string[]): Promise<void> {
 		// attach only unique tags
-		if (new Set(tags).size !== tags.length)
-			throw new TagControllerError(
-				"Can't attach duplicate tags",
-				TAG_ERROR_CODE.DUPLICATE,
-			);
+		const uniqueTags = Array.from(new Set(tags));
 
 		await this.db.get().transaction(async (tx) => {
 			const db = wrapDB(tx);
@@ -322,7 +318,7 @@ export class TagsController {
 			if (tags.length > 0) {
 				await db.query(
 					qb.sql`INSERT INTO attached_tags(workspace_id,source,target) VALUES ${qb.set(
-						tags.map((tagId) =>
+						uniqueTags.map((tagId) =>
 							qb.values([this.workspace, tagId, target]).withParenthesis(),
 						),
 					)}`,

--- a/src/core/storage/interop/import/NotesImporter.test.ts
+++ b/src/core/storage/interop/import/NotesImporter.test.ts
@@ -515,44 +515,6 @@ describe('Import notes with different options', () => {
 				}),
 			]);
 		});
-
-		test('does not throw when importing note with duplicate tags when convertPathToTag is never', async () => {
-			const db = await dbPromise;
-			const appContext = createAppContext(db, fileManager);
-
-			const importer = new NotesImporter(appContext, {
-				noteExtensions: ['.md'],
-				convertPathToTag: 'never',
-			});
-
-			await expect(
-				importer.import(
-					createFileManagerMock({
-						'/dev/ops/note.md': createTextBuffer(
-							'---\ntags:\n - dev\n - dev/ops\n - new tag\n---\nHello world!',
-						),
-						'/foo/note.md': createTextBuffer(
-							'---\ntags:\n - dev\n - dev\n - dev\n - dev\n - new tag\n---\nHello world!',
-						),
-					}),
-				),
-			).resolves.not.toThrow();
-
-			await expect(appContext.tagsRegistry.getTags()).resolves.toEqual([
-				expect.objectContaining({
-					name: 'dev',
-					resolvedName: 'dev',
-				}),
-				expect.objectContaining({
-					name: 'ops',
-					resolvedName: 'dev/ops',
-				}),
-				expect.objectContaining({
-					name: 'new tag',
-					resolvedName: 'new tag',
-				}),
-			]);
-		});
 	});
 });
 

--- a/src/core/storage/interop/import/index.ts
+++ b/src/core/storage/interop/import/index.ts
@@ -300,10 +300,10 @@ export class NotesImporter {
 					const tagName = noteDirPath.split('/').filter(Boolean).join('/');
 					const [pathTagId] = await this.getTagIds([tagName]);
 
-					await tagsRegistry.setAttachedTags(
-						noteId,
-						Array.from(new Set([...attachedTagIds, pathTagId])),
-					);
+					await tagsRegistry.setAttachedTags(noteId, [
+						...attachedTagIds,
+						pathTagId,
+					]);
 				}
 			}
 
@@ -366,7 +366,7 @@ export class NotesImporter {
 			tagsToAttach.push(createdTagId);
 		}
 
-		return Array.from(new Set(tagsToAttach));
+		return tagsToAttach;
 	}
 
 	private readonly uploadedFiles: Record<string, Promise<string | null>> = {};


### PR DESCRIPTION
Closes #136 

**Changes:**
- Added checks in TagsController for tag uniqueness, added test
- Added tests for NotesImporter
- Updated drawing import process