### PR TITLE
fix: focus on empty rich editor

### DIFF
--- a/src/features/NoteEditor/RichEditor/RichEditorContent.tsx
+++ b/src/features/NoteEditor/RichEditor/RichEditorContent.tsx
@@ -121,6 +121,7 @@ export const RichEditorContent = ({
 							bottom={0}
 							paddingInline="0.5rem"
 							pointerEvents="none"
+							color="typography.secondary"
 						>
 							{placeholder}
 						</Box>


### PR DESCRIPTION
Fixes #157

In case a rich editor have no text - it have no text nodes to focus.

As a solution now we set focus on root node.