### PR TITLE
fix: context menus are automatically clicked when opens

### DIFF
--- a/src/electron/requests/contextMenu/renderer.ts
+++ b/src/electron/requests/contextMenu/renderer.ts
@@ -9,3 +9,8 @@ export type ContextMenuRequestProps = {
 };
 
 export const { open: openContextMenu } = contextMenuChannel.client(ipcRendererFetcher);
+
+export const getContextMenuCoords = (event: MouseEvent) => ({
+	x: event.screenX,
+	y: event.screenY,
+});

--- a/src/features/MainScreen/NotesListPanel/NotesList.tsx
+++ b/src/features/MainScreen/NotesListPanel/NotesList.tsx
@@ -3,6 +3,7 @@ import { Box, Text, VStack } from '@chakra-ui/react';
 import { NotePreview } from '@components/NotePreview/NotePreview';
 import { getNoteTitle } from '@core/features/notes/utils';
 import { TELEMETRY_EVENT_NAME } from '@core/features/telemetry';
+import { getContextMenuCoords } from '@electron/requests/contextMenu/renderer';
 import { useTelemetryTracker } from '@features/telemetry';
 import { useNoteActions } from '@hooks/notes/useNoteActions';
 import { useUpdateNotes } from '@hooks/notes/useUpdateNotes';
@@ -131,10 +132,10 @@ export const NotesList: FC<NotesListProps> = () => {
 										)
 									}
 									onContextMenu={(evt) => {
-										openNoteContextMenu(note, {
-											x: evt.screenX,
-											y: evt.screenY,
-										});
+										openNoteContextMenu(
+											note,
+											getContextMenuCoords(evt.nativeEvent),
+										);
 									}}
 									onClick={() => {
 										noteActions.click(note.id);

--- a/src/features/MainScreen/TagsPanel/TagsList.tsx
+++ b/src/features/MainScreen/TagsPanel/TagsList.tsx
@@ -2,6 +2,7 @@ import React, { FC, ReactNode, useMemo, useState } from 'react';
 import { FaChevronDown, FaChevronUp, FaHashtag } from 'react-icons/fa6';
 import { Button, HStack, Text } from '@chakra-ui/react';
 import { ListItem, NestedList } from '@components/NestedList';
+import { getContextMenuCoords } from '@electron/requests/contextMenu/renderer';
 
 import { TagContextMenuCallbacks, useTagContextMenu } from './useTagContextMenu';
 
@@ -60,7 +61,7 @@ export const TagsList: FC<ITagsListProps> = ({
 						padding="0.4rem"
 						alignItems="center"
 						onContextMenu={(evt) => {
-							onTagMenu(id, { x: evt.screenX, y: evt.screenY });
+							onTagMenu(id, getContextMenuCoords(evt.nativeEvent));
 						}}
 					>
 						<FaHashtag size={14} />

--- a/src/features/NotesContainer/OpenedNotesPanel.tsx
+++ b/src/features/NotesContainer/OpenedNotesPanel.tsx
@@ -3,6 +3,7 @@ import { FaXmark } from 'react-icons/fa6';
 import { Box, HStack, Tab, TabList, Tabs, Text } from '@chakra-ui/react';
 import { INote, NoteId } from '@core/features/notes';
 import { getNoteTitle } from '@core/features/notes/utils';
+import { getContextMenuCoords } from '@electron/requests/contextMenu/renderer';
 
 import { useNoteContextMenu } from './NoteContextMenu/useNoteContextMenu';
 
@@ -109,10 +110,10 @@ export const OpenedNotesPanel: FC<TopBarProps> = ({
 								// Prevent text selection on macOS
 								evt.preventDefault();
 
-								openNoteContextMenu(note, {
-									x: evt.screenX,
-									y: evt.screenY,
-								});
+								openNoteContextMenu(
+									note,
+									getContextMenuCoords(evt.nativeEvent),
+								);
 							}}
 						>
 							<HStack gap=".5rem" w="100%" justifyContent="space-between">


### PR DESCRIPTION
Fixes #209

The problem cause is we used a pageX/Y coordinates that does not consider a window zoom properly.

Now we use a [screen coordinates](https://developer.mozilla.org/en-US/docs/Web/API/CSSOM_view_API/Coordinate_systems#screen) via helper to ensure a consistent coordinates use.