### PR TITLE
fix: context menu appears on middle of screen

### DIFF
--- a/src/electron/requests/contextMenu/renderer.ts
+++ b/src/electron/requests/contextMenu/renderer.ts
@@ -12,7 +12,12 @@ export type ContextMenuRequestProps = {
 
 export const { open: openContextMenu } = contextMenuChannel.client(ipcRendererFetcher);
 
-export const getContextMenuCoords = (event: MouseEvent) => ({
-	x: Math.ceil(event.pageX * getZoomFactor()),
-	y: Math.ceil(event.pageY * getZoomFactor()),
-});
+export const getContextMenuCoords = (event: MouseEvent) => {
+	// Consider zoom factor to draw context menu on proper coordinates for scaled windows
+	// With no zoom factor, context menu will be rendered under pointer, and click random option
+	const zoomFactor = getZoomFactor();
+	return {
+		x: Math.ceil(event.pageX * zoomFactor),
+		y: Math.ceil(event.pageY * zoomFactor),
+	};
+};


### PR DESCRIPTION
Fixes #212

It seem a problem cause is we use screen coordinates. We cannot to use page coordinates because appears an original problem from #210

I figured out the problem may be solved if we will apply current zoom factor to a page coordinates. The result coordinate will be correlate with a page coordinates then.