### PR TITLE
fix: white screen after deleting a workspace

### DIFF
--- a/src/features/App/Settings/sections/WorkspaceSettings.tsx
+++ b/src/features/App/Settings/sections/WorkspaceSettings.tsx
@@ -118,7 +118,7 @@ export const WorkspaceSettings = () => {
 			attachments,
 		}).fixAll();
 
-		// Delete workspace config directory
+		// Delete workspace directory
 		await workspaceFiles.delete([currentWorkspace.workspaceId]);
 
 		dispatch(

--- a/src/features/App/Settings/sections/WorkspaceSettings.tsx
+++ b/src/features/App/Settings/sections/WorkspaceSettings.tsx
@@ -18,7 +18,7 @@ import { FilesIntegrityController } from '@core/features/integrity/FilesIntegrit
 import { TELEMETRY_EVENT_NAME } from '@core/features/telemetry';
 import { WorkspacesController } from '@core/features/workspaces/WorkspacesController';
 import { useVaultStorage } from '@features/files';
-import { getWorkspacePath } from '@features/files/paths';
+import { getWorkspaceRoot } from '@features/files/paths';
 import { useWorkspacesList } from '@features/MainScreen/WorkspacesPanel/useWorkspacesList';
 import {
 	WorkspaceCreatePopup,
@@ -80,7 +80,7 @@ export const WorkspaceSettings = () => {
 	const files = useFilesRegistry();
 	const filesController = useFilesController();
 	const attachments = useAttachmentsController();
-	const workspaceFilesController = useVaultStorage();
+	const workspaceFiles = useVaultStorage(getWorkspaceRoot());
 
 	const isOtherWorkspacesExists = workspaces.workspaces.length > 1;
 	const onDelete = useCallback(async () => {
@@ -119,9 +119,7 @@ export const WorkspaceSettings = () => {
 		}).fixAll();
 
 		// Delete workspace config directory
-		await workspaceFilesController.delete([
-			getWorkspacePath(currentWorkspace.workspaceId),
-		]);
+		await workspaceFiles.delete([currentWorkspace.workspaceId]);
 
 		dispatch(
 			workspacesApi.setActiveWorkspace({
@@ -144,7 +142,7 @@ export const WorkspaceSettings = () => {
 		currentWorkspace.workspaceId,
 		currentWorkspace.profileId,
 		attachments,
-		workspaceFilesController,
+		workspaceFiles,
 		dispatch,
 		workspacesManager,
 	]);

--- a/src/features/App/Settings/sections/WorkspaceSettings.tsx
+++ b/src/features/App/Settings/sections/WorkspaceSettings.tsx
@@ -120,7 +120,7 @@ export const WorkspaceSettings = () => {
 			attachments,
 		}).fixAll();
 
-		// Delete dir with workspace
+		// Delete workspace config directory
 		const workspaceFileController = new FileController(
 			`workspaces/${currentWorkspace.workspaceId}`,
 			profileFileManager,

--- a/src/features/App/Settings/sections/WorkspaceSettings.tsx
+++ b/src/features/App/Settings/sections/WorkspaceSettings.tsx
@@ -18,7 +18,7 @@ import { FilesIntegrityController } from '@core/features/integrity/FilesIntegrit
 import { TELEMETRY_EVENT_NAME } from '@core/features/telemetry';
 import { WorkspacesController } from '@core/features/workspaces/WorkspacesController';
 import { useVaultStorage } from '@features/files';
-import { getWorkspaceRoot } from '@features/files/paths';
+import { getWorkspacePath } from '@features/files/paths';
 import { useWorkspacesList } from '@features/MainScreen/WorkspacesPanel/useWorkspacesList';
 import {
 	WorkspaceCreatePopup,
@@ -80,7 +80,9 @@ export const WorkspaceSettings = () => {
 	const files = useFilesRegistry();
 	const filesController = useFilesController();
 	const attachments = useAttachmentsController();
-	const workspaceFiles = useVaultStorage(getWorkspacePath(currentWorkspace.workspaceId));
+	const workspaceFiles = useVaultStorage(
+		getWorkspacePath(currentWorkspace.workspaceId),
+	);
 
 	const isOtherWorkspacesExists = workspaces.workspaces.length > 1;
 	const onDelete = useCallback(async () => {

--- a/src/features/App/Settings/sections/WorkspaceSettings.tsx
+++ b/src/features/App/Settings/sections/WorkspaceSettings.tsx
@@ -14,7 +14,6 @@ import { Features } from '@components/Features/Features';
 import { FeaturesGroup } from '@components/Features/Group';
 import { FeaturesOption } from '@components/Features/Option/FeaturesOption';
 import { RelaxedInput } from '@components/RelaxedInput';
-import { FileController } from '@core/features/files/FileController';
 import { FilesIntegrityController } from '@core/features/integrity/FilesIntegrityController';
 import { TELEMETRY_EVENT_NAME } from '@core/features/telemetry';
 import { WorkspacesController } from '@core/features/workspaces/WorkspacesController';
@@ -44,6 +43,7 @@ import {
 	useFilesRegistry,
 	useNotesRegistry,
 	useTagsRegistry,
+	useWorkspaceFilesController,
 } from '../../Workspace/WorkspaceProvider';
 
 export const WorkspaceSettings = () => {
@@ -52,7 +52,7 @@ export const WorkspaceSettings = () => {
 	const telemetry = useTelemetryTracker();
 
 	const {
-		profile: { db, files: profileFileManager },
+		profile: { db },
 	} = useProfileControls();
 
 	const { abort: abortImport } = useImportNotesPreset();
@@ -79,6 +79,7 @@ export const WorkspaceSettings = () => {
 	const files = useFilesRegistry();
 	const filesController = useFilesController();
 	const attachments = useAttachmentsController();
+	const workspaceFileController = useWorkspaceFilesController();
 
 	const isOtherWorkspacesExists = workspaces.workspaces.length > 1;
 	const onDelete = useCallback(async () => {
@@ -117,10 +118,6 @@ export const WorkspaceSettings = () => {
 		}).fixAll();
 
 		// Delete workspace config directory
-		const workspaceFileController = new FileController(
-			`workspaces/${currentWorkspace.workspaceId}`,
-			profileFileManager,
-		);
 		await workspaceFileController.delete();
 
 		dispatch(
@@ -133,19 +130,19 @@ export const WorkspaceSettings = () => {
 		await workspacesManager.delete([currentWorkspace.workspaceId]);
 		await workspaces.update();
 	}, [
+		workspaces,
+		workspaceInfo.name,
+		telemetry,
 		abortImport,
-		attachments,
-		currentWorkspace.profileId,
-		currentWorkspace.workspaceId,
-		dispatch,
+		tags,
+		notes,
 		files,
 		filesController,
-		profileFileManager,
-		notes,
-		tags,
-		telemetry,
-		workspaceInfo.name,
-		workspaces,
+		currentWorkspace.workspaceId,
+		currentWorkspace.profileId,
+		attachments,
+		workspaceFileController,
+		dispatch,
 		workspacesManager,
 	]);
 

--- a/src/features/App/Settings/sections/WorkspaceSettings.tsx
+++ b/src/features/App/Settings/sections/WorkspaceSettings.tsx
@@ -17,6 +17,8 @@ import { RelaxedInput } from '@components/RelaxedInput';
 import { FilesIntegrityController } from '@core/features/integrity/FilesIntegrityController';
 import { TELEMETRY_EVENT_NAME } from '@core/features/telemetry';
 import { WorkspacesController } from '@core/features/workspaces/WorkspacesController';
+import { useVaultStorage } from '@features/files';
+import { getWorkspacePath } from '@features/files/paths';
 import { useWorkspacesList } from '@features/MainScreen/WorkspacesPanel/useWorkspacesList';
 import {
 	WorkspaceCreatePopup,
@@ -43,7 +45,6 @@ import {
 	useFilesRegistry,
 	useNotesRegistry,
 	useTagsRegistry,
-	useWorkspaceFileController,
 } from '../../Workspace/WorkspaceProvider';
 
 export const WorkspaceSettings = () => {
@@ -79,7 +80,7 @@ export const WorkspaceSettings = () => {
 	const files = useFilesRegistry();
 	const filesController = useFilesController();
 	const attachments = useAttachmentsController();
-	const workspaceFileController = useWorkspaceFileController();
+	const workspaceFilesController = useVaultStorage();
 
 	const isOtherWorkspacesExists = workspaces.workspaces.length > 1;
 	const onDelete = useCallback(async () => {
@@ -118,7 +119,9 @@ export const WorkspaceSettings = () => {
 		}).fixAll();
 
 		// Delete workspace config directory
-		await workspaceFileController.delete();
+		await workspaceFilesController.delete([
+			getWorkspacePath(currentWorkspace.workspaceId),
+		]);
 
 		dispatch(
 			workspacesApi.setActiveWorkspace({
@@ -141,7 +144,7 @@ export const WorkspaceSettings = () => {
 		currentWorkspace.workspaceId,
 		currentWorkspace.profileId,
 		attachments,
-		workspaceFileController,
+		workspaceFilesController,
 		dispatch,
 		workspacesManager,
 	]);

--- a/src/features/App/Settings/sections/WorkspaceSettings.tsx
+++ b/src/features/App/Settings/sections/WorkspaceSettings.tsx
@@ -52,7 +52,7 @@ export const WorkspaceSettings = () => {
 	const telemetry = useTelemetryTracker();
 
 	const {
-		profile: { db },
+		profile: { db, files: profileFileManager },
 	} = useProfileControls();
 
 	const { abort: abortImport } = useImportNotesPreset();
@@ -79,10 +79,6 @@ export const WorkspaceSettings = () => {
 	const files = useFilesRegistry();
 	const filesController = useFilesController();
 	const attachments = useAttachmentsController();
-
-	const {
-		profile: { files: profileFileManager },
-	} = useProfileControls();
 
 	const isOtherWorkspacesExists = workspaces.workspaces.length > 1;
 	const onDelete = useCallback(async () => {

--- a/src/features/App/Settings/sections/WorkspaceSettings.tsx
+++ b/src/features/App/Settings/sections/WorkspaceSettings.tsx
@@ -43,7 +43,7 @@ import {
 	useFilesRegistry,
 	useNotesRegistry,
 	useTagsRegistry,
-	useWorkspaceFilesController,
+	useWorkspaceFileController,
 } from '../../Workspace/WorkspaceProvider';
 
 export const WorkspaceSettings = () => {
@@ -79,7 +79,7 @@ export const WorkspaceSettings = () => {
 	const files = useFilesRegistry();
 	const filesController = useFilesController();
 	const attachments = useAttachmentsController();
-	const workspaceFileController = useWorkspaceFilesController();
+	const workspaceFileController = useWorkspaceFileController();
 
 	const isOtherWorkspacesExists = workspaces.workspaces.length > 1;
 	const onDelete = useCallback(async () => {

--- a/src/features/App/Settings/sections/WorkspaceSettings.tsx
+++ b/src/features/App/Settings/sections/WorkspaceSettings.tsx
@@ -119,7 +119,7 @@ export const WorkspaceSettings = () => {
 		}).fixAll();
 
 		// Delete workspace directory
-		await workspaceFiles.delete([currentWorkspace.workspaceId]);
+		await workspaceFiles.delete(['/']);
 
 		dispatch(
 			workspacesApi.setActiveWorkspace({

--- a/src/features/App/Settings/sections/WorkspaceSettings.tsx
+++ b/src/features/App/Settings/sections/WorkspaceSettings.tsx
@@ -14,6 +14,7 @@ import { Features } from '@components/Features/Features';
 import { FeaturesGroup } from '@components/Features/Group';
 import { FeaturesOption } from '@components/Features/Option/FeaturesOption';
 import { RelaxedInput } from '@components/RelaxedInput';
+import { FileController } from '@core/features/files/FileController';
 import { FilesIntegrityController } from '@core/features/integrity/FilesIntegrityController';
 import { TELEMETRY_EVENT_NAME } from '@core/features/telemetry';
 import { WorkspacesController } from '@core/features/workspaces/WorkspacesController';
@@ -79,6 +80,10 @@ export const WorkspaceSettings = () => {
 	const filesController = useFilesController();
 	const attachments = useAttachmentsController();
 
+	const {
+		profile: { files: profileFileManager },
+	} = useProfileControls();
+
 	const isOtherWorkspacesExists = workspaces.workspaces.length > 1;
 	const onDelete = useCallback(async () => {
 		const nextWorkspace = workspaces.workspaces.find(
@@ -115,6 +120,13 @@ export const WorkspaceSettings = () => {
 			attachments,
 		}).fixAll();
 
+		// Delete dir with workspace
+		const workspaceFileController = new FileController(
+			`workspaces/${currentWorkspace.workspaceId}`,
+			profileFileManager,
+		);
+		await workspaceFileController.delete();
+
 		dispatch(
 			workspacesApi.setActiveWorkspace({
 				workspaceId: nextWorkspace.id,
@@ -132,6 +144,7 @@ export const WorkspaceSettings = () => {
 		dispatch,
 		files,
 		filesController,
+		profileFileManager,
 		notes,
 		tags,
 		telemetry,

--- a/src/features/App/Settings/sections/WorkspaceSettings.tsx
+++ b/src/features/App/Settings/sections/WorkspaceSettings.tsx
@@ -80,7 +80,7 @@ export const WorkspaceSettings = () => {
 	const files = useFilesRegistry();
 	const filesController = useFilesController();
 	const attachments = useAttachmentsController();
-	const workspaceFiles = useVaultStorage(getWorkspaceRoot());
+	const workspaceFiles = useVaultStorage(getWorkspacePath(currentWorkspace.workspaceId));
 
 	const isOtherWorkspacesExists = workspaces.workspaces.length > 1;
 	const onDelete = useCallback(async () => {

--- a/src/features/App/Workspace/WorkspaceProvider.tsx
+++ b/src/features/App/Workspace/WorkspaceProvider.tsx
@@ -4,6 +4,7 @@ import { EventBus } from '@api/events/EventBus';
 import { WorkspaceEventsPayloadMap } from '@api/events/workspace';
 import { AttachmentsController } from '@core/features/attachments/AttachmentsController';
 import { IFilesStorage } from '@core/features/files';
+import { FileController } from '@core/features/files/FileController';
 import { FilesController } from '@core/features/files/FilesController';
 import { INote } from '@core/features/notes';
 import { INotesController } from '@core/features/notes/controller';
@@ -46,6 +47,11 @@ export const useFilesRegistry = createContextGetterHook(FilesRegistryContext);
 export const FilesControllerContext = createContext<IFilesStorage | null>(null);
 export const useFilesController = createContextGetterHook(FilesControllerContext);
 
+export const WorkspaceFilesControllerContext = createContext<FileController | null>(null);
+export const useWorkspaceFilesController = createContextGetterHook(
+	WorkspaceFilesControllerContext,
+);
+
 export interface WorkspaceProviderProps extends PropsWithChildren {
 	notesApi: NotesApi;
 	filesController: IFilesStorage;
@@ -54,6 +60,7 @@ export interface WorkspaceProviderProps extends PropsWithChildren {
 	tagsRegistry: TagsController;
 	notesRegistry: INotesController;
 	notesHistory: NoteVersions;
+	workspaceFileController: FileController;
 }
 
 export const WorkspaceProvider: FC<WorkspaceProviderProps> = ({
@@ -65,6 +72,7 @@ export const WorkspaceProvider: FC<WorkspaceProviderProps> = ({
 	notesRegistry,
 	notesHistory,
 	children,
+	workspaceFileController,
 }) => {
 	const [eventBus] = useState(() => {
 		const event = createEvent<{
@@ -93,13 +101,19 @@ export const WorkspaceProvider: FC<WorkspaceProviderProps> = ({
 						<AttachmentsControllerContext.Provider
 							value={attachmentsController}
 						>
-							<TagsRegistryContext.Provider value={tagsRegistry}>
-								<NotesRegistryContext.Provider value={notesRegistry}>
-									<NotesHistoryContext.Provider value={notesHistory}>
-										{children}
-									</NotesHistoryContext.Provider>
-								</NotesRegistryContext.Provider>
-							</TagsRegistryContext.Provider>
+							<WorkspaceFilesControllerContext.Provider
+								value={workspaceFileController}
+							>
+								<TagsRegistryContext.Provider value={tagsRegistry}>
+									<NotesRegistryContext.Provider value={notesRegistry}>
+										<NotesHistoryContext.Provider
+											value={notesHistory}
+										>
+											{children}
+										</NotesHistoryContext.Provider>
+									</NotesRegistryContext.Provider>
+								</TagsRegistryContext.Provider>
+							</WorkspaceFilesControllerContext.Provider>
 						</AttachmentsControllerContext.Provider>
 					</FilesControllerContext.Provider>
 				</FilesRegistryContext.Provider>

--- a/src/features/App/Workspace/WorkspaceProvider.tsx
+++ b/src/features/App/Workspace/WorkspaceProvider.tsx
@@ -47,9 +47,9 @@ export const useFilesRegistry = createContextGetterHook(FilesRegistryContext);
 export const FilesControllerContext = createContext<IFilesStorage | null>(null);
 export const useFilesController = createContextGetterHook(FilesControllerContext);
 
-export const WorkspaceFilesControllerContext = createContext<FileController | null>(null);
-export const useWorkspaceFilesController = createContextGetterHook(
-	WorkspaceFilesControllerContext,
+export const WorkspaceFileControllerContext = createContext<FileController | null>(null);
+export const useWorkspaceFileController = createContextGetterHook(
+	WorkspaceFileControllerContext,
 );
 
 export interface WorkspaceProviderProps extends PropsWithChildren {
@@ -101,7 +101,7 @@ export const WorkspaceProvider: FC<WorkspaceProviderProps> = ({
 						<AttachmentsControllerContext.Provider
 							value={attachmentsController}
 						>
-							<WorkspaceFilesControllerContext.Provider
+							<WorkspaceFileControllerContext.Provider
 								value={workspaceFileController}
 							>
 								<TagsRegistryContext.Provider value={tagsRegistry}>
@@ -113,7 +113,7 @@ export const WorkspaceProvider: FC<WorkspaceProviderProps> = ({
 										</NotesHistoryContext.Provider>
 									</NotesRegistryContext.Provider>
 								</TagsRegistryContext.Provider>
-							</WorkspaceFilesControllerContext.Provider>
+							</WorkspaceFileControllerContext.Provider>
 						</AttachmentsControllerContext.Provider>
 					</FilesControllerContext.Provider>
 				</FilesRegistryContext.Provider>

--- a/src/features/App/Workspace/WorkspaceProvider.tsx
+++ b/src/features/App/Workspace/WorkspaceProvider.tsx
@@ -4,7 +4,6 @@ import { EventBus } from '@api/events/EventBus';
 import { WorkspaceEventsPayloadMap } from '@api/events/workspace';
 import { AttachmentsController } from '@core/features/attachments/AttachmentsController';
 import { IFilesStorage } from '@core/features/files';
-import { FileController } from '@core/features/files/FileController';
 import { FilesController } from '@core/features/files/FilesController';
 import { INote } from '@core/features/notes';
 import { INotesController } from '@core/features/notes/controller';
@@ -47,11 +46,6 @@ export const useFilesRegistry = createContextGetterHook(FilesRegistryContext);
 export const FilesControllerContext = createContext<IFilesStorage | null>(null);
 export const useFilesController = createContextGetterHook(FilesControllerContext);
 
-export const WorkspaceFileControllerContext = createContext<FileController | null>(null);
-export const useWorkspaceFileController = createContextGetterHook(
-	WorkspaceFileControllerContext,
-);
-
 export interface WorkspaceProviderProps extends PropsWithChildren {
 	notesApi: NotesApi;
 	filesController: IFilesStorage;
@@ -60,7 +54,6 @@ export interface WorkspaceProviderProps extends PropsWithChildren {
 	tagsRegistry: TagsController;
 	notesRegistry: INotesController;
 	notesHistory: NoteVersions;
-	workspaceFileController: FileController;
 }
 
 export const WorkspaceProvider: FC<WorkspaceProviderProps> = ({
@@ -72,7 +65,6 @@ export const WorkspaceProvider: FC<WorkspaceProviderProps> = ({
 	notesRegistry,
 	notesHistory,
 	children,
-	workspaceFileController,
 }) => {
 	const [eventBus] = useState(() => {
 		const event = createEvent<{
@@ -101,19 +93,13 @@ export const WorkspaceProvider: FC<WorkspaceProviderProps> = ({
 						<AttachmentsControllerContext.Provider
 							value={attachmentsController}
 						>
-							<WorkspaceFileControllerContext.Provider
-								value={workspaceFileController}
-							>
-								<TagsRegistryContext.Provider value={tagsRegistry}>
-									<NotesRegistryContext.Provider value={notesRegistry}>
-										<NotesHistoryContext.Provider
-											value={notesHistory}
-										>
-											{children}
-										</NotesHistoryContext.Provider>
-									</NotesRegistryContext.Provider>
-								</TagsRegistryContext.Provider>
-							</WorkspaceFileControllerContext.Provider>
+							<TagsRegistryContext.Provider value={tagsRegistry}>
+								<NotesRegistryContext.Provider value={notesRegistry}>
+									<NotesHistoryContext.Provider value={notesHistory}>
+										{children}
+									</NotesHistoryContext.Provider>
+								</NotesRegistryContext.Provider>
+							</TagsRegistryContext.Provider>
 						</AttachmentsControllerContext.Provider>
 					</FilesControllerContext.Provider>
 				</FilesRegistryContext.Provider>

--- a/src/features/MainScreen/WorkspacesPanel/useWorkspacesList.tsx
+++ b/src/features/MainScreen/WorkspacesPanel/useWorkspacesList.tsx
@@ -22,9 +22,9 @@ export const useWorkspacesList = () => {
 		const updatedWorkspaces = await workspacesManager.getList();
 
 		dispatch(
-			workspacesApi.updateWorkspacesList({
+			workspacesApi.syncWorkspacesList({
 				profileId,
-				updatedWorkspaces,
+				workspacesList: updatedWorkspaces,
 			}),
 		);
 	}, [dispatch, profileId, workspacesManager]);

--- a/src/features/MainScreen/WorkspacesPanel/useWorkspacesList.tsx
+++ b/src/features/MainScreen/WorkspacesPanel/useWorkspacesList.tsx
@@ -3,11 +3,7 @@ import { WorkspacesController } from '@core/features/workspaces/WorkspacesContro
 import { useProfileControls } from '@features/App/Profile';
 import { useAppDispatch, useAppSelector } from '@state/redux/hooks';
 import { useWorkspaceData } from '@state/redux/profiles/hooks';
-import {
-	createWorkspaceObject,
-	selectWorkspaces,
-	workspacesApi,
-} from '@state/redux/profiles/profiles';
+import { selectWorkspaces, workspacesApi } from '@state/redux/profiles/profiles';
 
 export const useWorkspacesList = () => {
 	const dispatch = useAppDispatch();
@@ -25,44 +21,13 @@ export const useWorkspacesList = () => {
 	const update = useCallback(async () => {
 		const updatedWorkspaces = await workspacesManager.getList();
 
-		const newWorkspaces = updatedWorkspaces.filter(
-			(workspace) => !workspaces.some(({ id }) => id === workspace.id),
-		);
-
-		const mergedWorkspaces = structuredClone({
-			...Object.fromEntries(
-				workspaces.map((workspace) => [workspace.id, workspace]),
-			),
-			...Object.fromEntries(
-				newWorkspaces.map((workspace) => [
-					workspace.id,
-					createWorkspaceObject(workspace),
-				]),
-			),
-		});
-
-		// Update names
-		updatedWorkspaces.forEach((workspace) => {
-			mergedWorkspaces[workspace.id].name = workspace.name;
-		});
-
-		// Delete workspaces that no more exists
-		for (const id in mergedWorkspaces) {
-			const isWorkspaceExists = updatedWorkspaces.some(
-				(workspace) => workspace.id === id,
-			);
-			if (!isWorkspaceExists) {
-				delete mergedWorkspaces[id];
-			}
-		}
-
 		dispatch(
-			workspacesApi.setWorkspaces({
+			workspacesApi.updateWorkspacesList({
 				profileId,
-				workspaces: mergedWorkspaces,
+				updatedWorkspaces,
 			}),
 		);
-	}, [dispatch, profileId, workspaces, workspacesManager]);
+	}, [dispatch, profileId, workspacesManager]);
 
 	return { workspaces, update };
 };

--- a/src/features/MainScreen/WorkspacesPanel/useWorkspacesList.tsx
+++ b/src/features/MainScreen/WorkspacesPanel/useWorkspacesList.tsx
@@ -22,9 +22,9 @@ export const useWorkspacesList = () => {
 		const updatedWorkspaces = await workspacesManager.getList();
 
 		dispatch(
-			workspacesApi.syncWorkspacesList({
+			workspacesApi.setWorkspaces({
 				profileId,
-				workspacesList: updatedWorkspaces,
+				workspaces: updatedWorkspaces,
 			}),
 		);
 	}, [dispatch, profileId, workspacesManager]);

--- a/src/features/MainScreen/WorkspacesPanel/useWorkspacesList.tsx
+++ b/src/features/MainScreen/WorkspacesPanel/useWorkspacesList.tsx
@@ -22,7 +22,7 @@ export const useWorkspacesList = () => {
 		const updatedWorkspaces = await workspacesManager.getList();
 
 		dispatch(
-			workspacesApi.setWorkspaces({
+			workspacesApi.updateWorkspacesList({
 				profileId,
 				workspaces: updatedWorkspaces,
 			}),

--- a/src/features/files/paths.ts
+++ b/src/features/files/paths.ts
@@ -1,4 +1,7 @@
-export const getWorkspacePath = (workspaceId: string) => `/workspaces/${workspaceId}`;
+export const getWorkspaceRoot = () => `/workspaces`;
+
+export const getWorkspacePath = (workspaceId: string) =>
+	`${getWorkspaceRoot()}/${workspaceId}`;
 
 export const getWorkspaceFilesPath = (workspaceId: string) =>
 	`${getWorkspacePath(workspaceId)}/files`;

--- a/src/features/files/paths.ts
+++ b/src/features/files/paths.ts
@@ -1,7 +1,4 @@
-export const getWorkspaceRoot = () => `/workspaces`;
-
-export const getWorkspacePath = (workspaceId: string) =>
-	`${getWorkspaceRoot()}/${workspaceId}`;
+export const getWorkspacePath = (workspaceId: string) => `/workspaces/${workspaceId}`;
 
 export const getWorkspaceFilesPath = (workspaceId: string) =>
 	`${getWorkspacePath(workspaceId)}/files`;

--- a/src/features/files/paths.ts
+++ b/src/features/files/paths.ts
@@ -1,2 +1,4 @@
+export const getWorkspacePath = (workspaceId: string) => `/workspaces/${workspaceId}`;
+
 export const getWorkspaceFilesPath = (workspaceId: string) =>
-	`/workspaces/${workspaceId}/files`;
+	`${getWorkspacePath(workspaceId)}/files`;

--- a/src/state/redux/profiles/profiles.ts
+++ b/src/state/redux/profiles/profiles.ts
@@ -190,7 +190,7 @@ export const profilesSlice = createSlice({
 			state.activeProfile = payload;
 		},
 
-		setWorkspaces: (
+		updateWorkspacesList: (
 			state,
 			{
 				payload: { profileId, workspaces },
@@ -214,9 +214,11 @@ export const profilesSlice = createSlice({
 			});
 
 			// Delete workspaces that no more exists
-			const updatedIds = new Set(workspaces.map((workspace) => workspace.id));
+			const actualWorkspaceIds = new Set(
+				workspaces.map((workspace) => workspace.id),
+			);
 			for (const id in profile.workspaces) {
-				if (!updatedIds.has(id)) {
+				if (!actualWorkspaceIds.has(id)) {
 					delete profile.workspaces[id];
 				}
 			}

--- a/src/state/redux/profiles/profiles.ts
+++ b/src/state/redux/profiles/profiles.ts
@@ -254,7 +254,6 @@ export const profilesSlice = createSlice({
 			if (workspaceId) {
 				const workspace = profile.workspaces[workspaceId];
 				if (workspace && !workspace.touched) {
-					console.log('touch');
 					workspace.touched = true;
 				}
 			}

--- a/src/state/redux/profiles/profiles.ts
+++ b/src/state/redux/profiles/profiles.ts
@@ -190,20 +190,6 @@ export const profilesSlice = createSlice({
 			state.activeProfile = payload;
 		},
 
-		setWorkspaces: (
-			state,
-			{
-				payload: { profileId, workspaces },
-			}: PayloadAction<
-				ProfileScoped<{ workspaces: Record<string, WorkspaceData> }>
-			>,
-		) => {
-			const profile = state.profiles[profileId];
-			if (!profile) return;
-
-			profile.workspaces = workspaces;
-		},
-
 		syncWorkspacesList: (
 			state,
 			{
@@ -216,9 +202,7 @@ export const profilesSlice = createSlice({
 			if (!profile) return;
 
 			const workspaces = profile.workspaces;
-			if (!workspaces) return;
 
-			// Update workspaces list
 			workspacesList.forEach((workspace) => {
 				const existingWorkspace = workspaces[workspace.id];
 				if (existingWorkspace) {
@@ -226,12 +210,12 @@ export const profilesSlice = createSlice({
 					return;
 				}
 
-				// Crate new workspace
+				// Create new workspace
 				workspaces[workspace.id] = createWorkspaceObject(workspace);
 			});
 
 			// Delete workspaces that no more exists
-			const updatedIds = new Set(workspacesList.map((w) => w.id));
+			const updatedIds = new Set(workspacesList.map((workspace) => workspace.id));
 			for (const id in workspaces) {
 				if (!updatedIds.has(id)) {
 					delete workspaces[id];

--- a/src/state/redux/profiles/profiles.ts
+++ b/src/state/redux/profiles/profiles.ts
@@ -204,6 +204,41 @@ export const profilesSlice = createSlice({
 			profile.workspaces = workspaces;
 		},
 
+		updateWorkspacesList: (
+			state,
+			{
+				payload: { profileId, updatedWorkspaces },
+			}: PayloadAction<
+				ProfileScoped<{ updatedWorkspaces: { id: string; name: string }[] }>
+			>,
+		) => {
+			const profile = state.profiles[profileId];
+			if (!profile) return;
+
+			const workspaces = profile.workspaces;
+			if (!workspaces) return;
+
+			// Update workspaces list
+			updatedWorkspaces.forEach((workspace) => {
+				const existingWorkspace = workspaces[workspace.id];
+
+				if (existingWorkspace) {
+					existingWorkspace.name = workspace.name;
+					return;
+				}
+
+				workspaces[workspace.id] = createWorkspaceObject(workspace);
+			});
+
+			// Delete workspaces that no more exists
+			const updatedIds = new Set(updatedWorkspaces.map((w) => w.id));
+			for (const id in workspaces) {
+				if (!updatedIds.has(id)) {
+					delete workspaces[id];
+				}
+			}
+		},
+
 		setActiveWorkspace: (
 			state,
 			{
@@ -219,6 +254,7 @@ export const profilesSlice = createSlice({
 			if (workspaceId) {
 				const workspace = profile.workspaces[workspaceId];
 				if (workspace && !workspace.touched) {
+					console.log('touch');
 					workspace.touched = true;
 				}
 			}

--- a/src/state/redux/profiles/profiles.ts
+++ b/src/state/redux/profiles/profiles.ts
@@ -190,35 +190,34 @@ export const profilesSlice = createSlice({
 			state.activeProfile = payload;
 		},
 
-		syncWorkspacesList: (
+		setWorkspaces: (
 			state,
 			{
-				payload: { profileId, workspacesList },
+				payload: { profileId, workspaces },
 			}: PayloadAction<
-				ProfileScoped<{ workspacesList: { id: string; name: string }[] }>
+				ProfileScoped<{ workspaces: { id: string; name: string }[] }>
 			>,
 		) => {
 			const profile = state.profiles[profileId];
 			if (!profile) return;
 
-			const workspaces = profile.workspaces;
-
-			workspacesList.forEach((workspace) => {
-				const existingWorkspace = workspaces[workspace.id];
+			workspaces.forEach((workspace) => {
+				// Rename
+				const existingWorkspace = profile.workspaces[workspace.id];
 				if (existingWorkspace) {
 					existingWorkspace.name = workspace.name;
 					return;
 				}
 
 				// Create new workspace
-				workspaces[workspace.id] = createWorkspaceObject(workspace);
+				profile.workspaces[workspace.id] = createWorkspaceObject(workspace);
 			});
 
 			// Delete workspaces that no more exists
-			const updatedIds = new Set(workspacesList.map((workspace) => workspace.id));
-			for (const id in workspaces) {
+			const updatedIds = new Set(workspaces.map((workspace) => workspace.id));
+			for (const id in profile.workspaces) {
 				if (!updatedIds.has(id)) {
-					delete workspaces[id];
+					delete profile.workspaces[id];
 				}
 			}
 		},

--- a/src/state/redux/profiles/profiles.ts
+++ b/src/state/redux/profiles/profiles.ts
@@ -204,12 +204,12 @@ export const profilesSlice = createSlice({
 			profile.workspaces = workspaces;
 		},
 
-		updateWorkspacesList: (
+		syncWorkspacesList: (
 			state,
 			{
-				payload: { profileId, updatedWorkspaces },
+				payload: { profileId, workspacesList },
 			}: PayloadAction<
-				ProfileScoped<{ updatedWorkspaces: { id: string; name: string }[] }>
+				ProfileScoped<{ workspacesList: { id: string; name: string }[] }>
 			>,
 		) => {
 			const profile = state.profiles[profileId];
@@ -219,19 +219,19 @@ export const profilesSlice = createSlice({
 			if (!workspaces) return;
 
 			// Update workspaces list
-			updatedWorkspaces.forEach((workspace) => {
+			workspacesList.forEach((workspace) => {
 				const existingWorkspace = workspaces[workspace.id];
-
 				if (existingWorkspace) {
 					existingWorkspace.name = workspace.name;
 					return;
 				}
 
+				// Crate new workspace
 				workspaces[workspace.id] = createWorkspaceObject(workspace);
 			});
 
 			// Delete workspaces that no more exists
-			const updatedIds = new Set(updatedWorkspaces.map((w) => w.id));
+			const updatedIds = new Set(workspacesList.map((w) => w.id));
 			for (const id in workspaces) {
 				if (!updatedIds.has(id)) {
 					delete workspaces[id];


### PR DESCRIPTION
Closed #231 

**1) White Screen after delete:**
The bug happens because after deleting workspace the active workspace, its touch property is set to false, so it is not rendered. This occurs due to the following flow when deleting a workspace:
- Call `setActiveWorkspace`, which updates the touch property for the workspace.
- Call the `useWorkspacesList` hook to update the workspace list; the hook uses a stale closure where the active workspace’s touch is still false. When updating redux in this hook, we overwrite the `touch` property of the active workspace and we have bug

To fix this error, i moved the update workspaces logic from `useWorkspacesList` to Redux, so the reducer has the actual state where touch for the active workspace is true. 


**2) Workspace dir not deleted:**
This happens because we had no logic to delete this directory. I added.





<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added workspace file controller support so workspace-scoped files are managed and exposed where relevant.

* **Bug Fixes**
  * Workspace deletion now removes associated configuration files to prevent orphaned data.

* **Refactor**
  * Simplified workspace list synchronization and updated workspace store handling to perform targeted create/update/delete operations for more reliable state management.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->