### PR TITLE
fix: In MonacoEditor the caret jumps to the start

### DIFF
--- a/packages/app/src/features/MonakoEditor/MonacoEditor.tsx
+++ b/packages/app/src/features/MonakoEditor/MonacoEditor.tsx
@@ -273,20 +273,15 @@ export const MonacoEditor = ({
 		if (!editor) return;
 
 		if (editor.getValue() !== value) {
-			// Save the cursor position before calling setValue, because it resets the cursor to 0:0
-			const position = editor.getPosition();
-			editor.setValue(value);
+			const model = editor.getModel();
+			if (!model) return;
 
-			if (position) {
-				const model = editor.getModel();
-				if (!model) return;
-
-				// Keep the cursor within valid bounds in case the new value is shorter than the previous one
-				const line = Math.min(position.lineNumber, model.getLineCount());
-				const column = Math.min(position.column, model.getLineMaxColumn(line));
-
-				editor.setPosition({ lineNumber: line, column });
-			}
+			// Update content without resetting cursor position
+			model.pushEditOperations(
+				[],
+				[{ range: model.getFullModelRange(), text: value }],
+				() => null,
+			);
 		}
 	});
 

--- a/packages/app/src/features/MonakoEditor/MonacoEditor.tsx
+++ b/packages/app/src/features/MonakoEditor/MonacoEditor.tsx
@@ -278,7 +278,7 @@ export const MonacoEditor = ({
 
 			// Update content without resetting cursor position
 			model.pushEditOperations(
-				[],
+				editor.getSelections(),
 				[{ range: model.getFullModelRange(), text: value }],
 				() => null,
 			);

--- a/packages/app/src/features/MonakoEditor/MonacoEditor.tsx
+++ b/packages/app/src/features/MonakoEditor/MonacoEditor.tsx
@@ -273,7 +273,20 @@ export const MonacoEditor = ({
 		if (!editor) return;
 
 		if (editor.getValue() !== value) {
+			// Save the cursor position before calling setValue, because it resets the cursor to 0:0
+			const position = editor.getPosition();
 			editor.setValue(value);
+
+			if (position) {
+				const model = editor.getModel();
+				if (!model) return;
+
+				// Keep the cursor within valid bounds in case the new value is shorter than the previous one
+				const line = Math.min(position.lineNumber, model.getLineCount());
+				const column = Math.min(position.column, model.getLineMaxColumn(line));
+
+				editor.setPosition({ lineNumber: line, column });
+			}
 		}
 	});
 

--- a/packages/app/src/features/MonakoEditor/MonacoEditor.tsx
+++ b/packages/app/src/features/MonakoEditor/MonacoEditor.tsx
@@ -4,6 +4,7 @@ import React, {
 	Ref,
 	useCallback,
 	useEffect,
+	useLayoutEffect,
 	useRef,
 	useState,
 } from 'react';
@@ -268,22 +269,14 @@ export const MonacoEditor = ({
 	}, [isReadOnly]);
 
 	// Update value
-	useEffect(() => {
+	useLayoutEffect(() => {
 		const editor = editorRef.current;
 		if (!editor) return;
 
 		if (editor.getValue() !== value) {
-			const model = editor.getModel();
-			if (!model) return;
-
-			// Update content without resetting cursor position
-			model.pushEditOperations(
-				editor.getSelections(),
-				[{ range: model.getFullModelRange(), text: value }],
-				() => null,
-			);
+			editor.setValue(value);
 		}
-	});
+	}, [value]);
 
 	// Update config
 	useEffect(() => {


### PR DESCRIPTION
Closes #228 

When the user types text, a is triggered a code to update the note text. After the note updates, the Monaco editor compares its own current editor content with the updated note text  — if they differ, `setValue` is called to update editor content.

On Ubuntu, the note text was sometimes one character behind the editor content. This caused editor content updates to be called unnecessarily, which reset the cursor position. It is unclear why this happens on Ubuntu but not on other systems.

The fix was to replace `useEffect` with `useLayoutEffect`. It runs after React has applied the state change, but before the browser has painted the frame. At that point the browser is blocked and no new input events can arrive — the note text is to be up to date.


### Fix:

https://github.com/user-attachments/assets/9f923558-3a8b-4d9a-bbb6-71340007c4c6


### Bug:

https://github.com/user-attachments/assets/7f3c2900-dd79-4ef4-9d7b-9ef92beadc10




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced the Monaco editor's value synchronization mechanism to execute at the proper timing phase during the rendering cycle and only respond when the editor's value actually changes. This resolves timing inconsistencies, eliminates unnecessary operations, and ensures the editor maintains consistent and correct state throughout all value updates and user interactions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->