### PR TITLE
fix: Modal window for creating tags does not handle Enter

### DIFF
--- a/src/components/TagEditor/index.tsx
+++ b/src/components/TagEditor/index.tsx
@@ -93,10 +93,14 @@ export const TagEditor: FC<ITagEditorProps> = ({
 		setSelectedParentTag(parentTag ? parentTag : null);
 	}, [parentTagId, tags]);
 
+	const [isPending, setIsPending] = useState(false);
 	return (
 		<form
 			onSubmit={async (event) => {
 				event.preventDefault();
+				if (isPending) return;
+
+				setIsPending(true);
 				try {
 					const name = tagName.trim();
 
@@ -115,6 +119,8 @@ export const TagEditor: FC<ITagEditorProps> = ({
 					console.error(error);
 
 					setTagNameError('Unable to save the tag. Please try again.');
+				} finally {
+					setIsPending(false);
 				}
 			}}
 		>
@@ -158,10 +164,12 @@ export const TagEditor: FC<ITagEditorProps> = ({
 
 			<ModalFooter>
 				<HStack w="100%" justifyContent="end">
-					<Button type="submit" variant="accent">
+					<Button type="submit" variant="accent" isDisabled={isPending}>
 						{isEditingMode ? 'Save' : 'Add'}
 					</Button>
-					<Button onClick={onCancel}>Cancel</Button>
+					<Button onClick={onCancel} isDisabled={isPending}>
+						Cancel
+					</Button>
 				</HStack>
 			</ModalFooter>
 		</form>

--- a/src/components/TagEditor/index.tsx
+++ b/src/components/TagEditor/index.tsx
@@ -94,7 +94,30 @@ export const TagEditor: FC<ITagEditorProps> = ({
 	}, [parentTagId, tags]);
 
 	return (
-		<>
+		<form
+			onSubmit={async (event) => {
+				event.preventDefault();
+				try {
+					const name = tagName.trim();
+
+					const result = await onSave({
+						name,
+						parent: parentTagId,
+						...(isEditingMode && editedTag.id ? { id: editedTag.id } : {}),
+					});
+
+					if (!result.ok) {
+						setTagNameError(result.error);
+						return;
+					}
+					onCancel();
+				} catch (error) {
+					console.error(error);
+
+					setTagNameError('Unable to save the tag. Please try again.');
+				}
+			}}
+		>
 			<ModalCloseButton />
 			<ModalHeader>{isEditingMode ? 'Edit tag' : 'Add tag'}</ModalHeader>
 
@@ -135,39 +158,12 @@ export const TagEditor: FC<ITagEditorProps> = ({
 
 			<ModalFooter>
 				<HStack w="100%" justifyContent="end">
-					<Button
-						variant="accent"
-						onClick={async () => {
-							try {
-								const name = tagName.trim();
-
-								const result = await onSave({
-									name,
-									parent: parentTagId,
-									...(isEditingMode && editedTag.id
-										? { id: editedTag.id }
-										: {}),
-								});
-
-								if (!result.ok) {
-									setTagNameError(result.error);
-									return;
-								}
-								onCancel();
-							} catch (error) {
-								console.error(error);
-
-								setTagNameError(
-									'Unable to save the tag. Please try again.',
-								);
-							}
-						}}
-					>
+					<Button type="submit" variant="accent">
 						{isEditingMode ? 'Save' : 'Add'}
 					</Button>
 					<Button onClick={onCancel}>Cancel</Button>
 				</HStack>
 			</ModalFooter>
-		</>
+		</form>
 	);
 };

--- a/src/components/TagEditor/index.tsx
+++ b/src/components/TagEditor/index.tsx
@@ -167,9 +167,7 @@ export const TagEditor: FC<ITagEditorProps> = ({
 					<Button type="submit" variant="accent" isDisabled={isPending}>
 						{isEditingMode ? 'Save' : 'Add'}
 					</Button>
-					<Button onClick={onCancel} isDisabled={isPending}>
-						Cancel
-					</Button>
+					<Button onClick={onCancel}>Cancel</Button>
 				</HStack>
 			</ModalFooter>
 		</form>


### PR DESCRIPTION
Closes #247 

Add `form` wrapper to handle Enter key




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Tag editor now uses a standard form submit flow for saving.
  * Prevents duplicate submissions by disabling actions during async save.
  * Primary action is a submit button; tag names are trimmed before saving.
  * Validation and save errors are surfaced reliably; editor only closes after a successful save.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->