### PR TITLE
fix: Note is sometimes updates while opening

### DIFF
--- a/src/features/NoteEditor/RichEditor/plugins/Markdown/MarkdownSerializePlugin.tsx
+++ b/src/features/NoteEditor/RichEditor/plugins/Markdown/MarkdownSerializePlugin.tsx
@@ -1,7 +1,6 @@
-import React, { useEffect, useRef } from 'react';
+import { useEffect, useRef } from 'react';
 import { $setSelection } from 'lexical';
 import { useLexicalComposerContext } from '@lexical/react/LexicalComposerContext';
-import { OnChangePlugin } from '@lexical/react/LexicalOnChangePlugin';
 import { useDebouncedCallback } from '@utils/debounce/useDebouncedCallback';
 
 import { $convertFromMarkdownString, $convertToMarkdownString } from './markdownParser';
@@ -35,10 +34,13 @@ export const MarkdownSerializePlugin = ({
 		// Otherwise we may have bug when value is updated via `editor.update`, an `OnChangePlugin` will not trigger callback (because synthetic update) and if next value update will have previous value - update will be ignored.
 		serializedValueRef.current = null;
 
-		editor.update(() => {
-			$convertFromMarkdownString(value);
-			$setSelection(null);
-		});
+		editor.update(
+			() => {
+				$convertFromMarkdownString(value);
+				$setSelection(null);
+			},
+			{ tag: 'external-update' },
+		);
 	}, [editor, value]);
 
 	const onChange = (value: string) => {
@@ -58,15 +60,19 @@ export const MarkdownSerializePlugin = ({
 		{ wait: 500 },
 	);
 
-	return (
-		<OnChangePlugin
-			ignoreSelectionChange
-			onChange={(_, editor) => {
-				const isActive = isFocusedElement(editor.getRootElement());
-				if (!isActive) return;
+	useEffect(() => {
+		return editor.registerUpdateListener(({ tags, dirtyElements, dirtyLeaves }) => {
+			// Ignore non-user-initiated updates
+			if (tags.has('external-update')) return;
 
-				syncValue();
-			}}
-		/>
-	);
+			// Update only if there are actual changes
+			if (dirtyElements.size === 0 && dirtyLeaves.size === 0) return;
+
+			const isActive = isFocusedElement(editor.getRootElement());
+			if (!isActive) return;
+
+			syncValue();
+		});
+	}, [editor, syncValue]);
+	return null;
 };

--- a/src/features/NoteEditor/RichEditor/plugins/Markdown/MarkdownSerializePlugin.tsx
+++ b/src/features/NoteEditor/RichEditor/plugins/Markdown/MarkdownSerializePlugin.tsx
@@ -65,7 +65,9 @@ export const MarkdownSerializePlugin = ({
 		<OnChangePlugin
 			ignoreSelectionChange
 			onChange={(_, editor, tags) => {
-				// Ignore updates initiated by useEffect to prevent loop between editor and external state
+				// Skip programmatic (non-user) changes to avoid note updates without user actions
+				// The serializer may produce output that differs from the original input (due to serializer implementation),
+				// which would trigger note updates without any user action
 				if (tags.has('non-user-update')) return;
 
 				const isActive = isFocusedElement(editor.getRootElement());

--- a/src/features/NoteEditor/RichEditor/plugins/Markdown/MarkdownSerializePlugin.tsx
+++ b/src/features/NoteEditor/RichEditor/plugins/Markdown/MarkdownSerializePlugin.tsx
@@ -40,7 +40,7 @@ export const MarkdownSerializePlugin = ({
 				$convertFromMarkdownString(value);
 				$setSelection(null);
 			},
-			{ tag: 'external-update' },
+			{ tag: 'non-user-update' },
 		);
 	}, [editor, value]);
 
@@ -65,8 +65,8 @@ export const MarkdownSerializePlugin = ({
 		<OnChangePlugin
 			ignoreSelectionChange
 			onChange={(_, editor, tags) => {
-				// Ignore non-user-initiated updates
-				if (tags.has('external-update')) return;
+				// Ignore updates initiated by useEffect to prevent loop between editor and external state
+				if (tags.has('non-user-update')) return;
 
 				const isActive = isFocusedElement(editor.getRootElement());
 				if (!isActive) return;

--- a/src/features/NoteEditor/RichEditor/plugins/Markdown/MarkdownSerializePlugin.tsx
+++ b/src/features/NoteEditor/RichEditor/plugins/Markdown/MarkdownSerializePlugin.tsx
@@ -1,6 +1,7 @@
-import { useEffect, useRef } from 'react';
+import React, { useEffect, useRef } from 'react';
 import { $setSelection } from 'lexical';
 import { useLexicalComposerContext } from '@lexical/react/LexicalComposerContext';
+import { OnChangePlugin } from '@lexical/react/LexicalOnChangePlugin';
 import { useDebouncedCallback } from '@utils/debounce/useDebouncedCallback';
 
 import { $convertFromMarkdownString, $convertToMarkdownString } from './markdownParser';
@@ -60,19 +61,18 @@ export const MarkdownSerializePlugin = ({
 		{ wait: 500 },
 	);
 
-	useEffect(() => {
-		return editor.registerUpdateListener(({ tags, dirtyElements, dirtyLeaves }) => {
-			// Ignore non-user-initiated updates
-			if (tags.has('external-update')) return;
+	return (
+		<OnChangePlugin
+			ignoreSelectionChange
+			onChange={(_, editor, tags) => {
+				// Ignore non-user-initiated updates
+				if (tags.has('external-update')) return;
 
-			// Update only if there are actual changes
-			if (dirtyElements.size === 0 && dirtyLeaves.size === 0) return;
+				const isActive = isFocusedElement(editor.getRootElement());
+				if (!isActive) return;
 
-			const isActive = isFocusedElement(editor.getRootElement());
-			if (!isActive) return;
-
-			syncValue();
-		});
-	}, [editor, syncValue]);
-	return null;
+				syncValue();
+			}}
+		/>
+	);
 };


### PR DESCRIPTION
Closes #258 

When user open note, the RichEditor component receive the note text as property.
The serializer plugin react on that as on update, and serialize the input.
In case the input and output are different the change is triggered.
The output may be different because of different implementation of markdown parser/serializer.
It happens mostly when markdown contains advanced constructions like title for link in your example.

In scope of this PR we introduce the code to prevent serialization of any input except user input via keyboard into editor component.

Technically we mark any other inputs via special tag and skip serialization for changes with that tag.

---


The root problem: When we receive the external value - we update editor, this trigger the OnChangePlugin witch update external value and then note updated. But value is changed not user initiated. I suggests ignore this update and not update note in this case

The current flow in `MarkdownSerializePlugin`:
**External value update:** 
* Effect triggers
* Check if value equals local ref - if equal, early return (ignore own update)
* Update editor

**OnChangePlugin triggers:**
* Serialize markdown to string and save result to local ref
* Update external state

User made no real changes, but the note was updated.

**Fix:** 
Tag editor updates made by us in useEffect and ignore them in `OnChangePlugin`.

Updated flow in `MarkdownSerializePlugin`:

**External value changed:**
* Effect triggers
* Check if value equals local ref — if equal, early return
* Update editor with special tag

**OnChangePlugin triggers:**
* Check if update has special tag — if so, skip state update *(not a user-initiated change)*
* Serialize editor nodes to markdown string and save result to local ref
* Update external state

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed markdown editor synchronization so programmatic/internal editor updates no longer trigger the debounced sync to external state. Only direct user edits now cause markdown→prop syncing, reducing redundant updates, preventing spurious change events, and improving overall change handling and performance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->