### PR TITLE
fix: native menus contains i18n key path fallbacks instead of text

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7,7 +7,7 @@
 		"": {
 			"name": "deepink",
 			"version": "0.0.0",
-			"license": " AGPL-3.0",
+			"license": " Apache 2.0",
 			"workspaces": [
 				"packages/*"
 			],
@@ -33454,8 +33454,8 @@
 			}
 		},
 		"packages/app": {
-			"version": "0.1.1",
-			"license": " AGPL-3.0",
+			"version": "0.1.2",
+			"license": "Apache 2.0",
 			"dependencies": {
 				"@chakra-ui/react": "^2.10.9",
 				"@emotion/react": "^11.14.0",

--- a/packages/app/package.json
+++ b/packages/app/package.json
@@ -3,7 +3,7 @@
 	"productName": "Deepink",
 	"description": "Privacy focused notes",
 	"author": "Robert Vitonsky",
-	"version": "0.1.1",
+	"version": "0.1.2",
 	"main": "dist/main.js",
 	"homepage": "https://github.com/DeepinkApp/deepink",
 	"bugs": {

--- a/packages/app/src/electron/requests/files/index.ts
+++ b/packages/app/src/electron/requests/files/index.ts
@@ -4,5 +4,4 @@ export const filesChannel = createChannel<{
 	importNotes(): Promise<Record<string, ArrayBuffer>>;
 	selectDirectory(): Promise<null | string[]>;
 	getUserDataPath(path?: string): Promise<string>;
-	getResourcesPath(path: string): Promise<string>;
 }>({ name: 'files' });

--- a/packages/app/src/electron/requests/files/main.ts
+++ b/packages/app/src/electron/requests/files/main.ts
@@ -14,10 +14,6 @@ export const serveFiles = () =>
 			return filesUtils.getUserDataPath(path);
 		},
 
-		async getResourcesPath({ req: [path] }) {
-			return filesUtils.getResourcesPath(path);
-		},
-
 		async selectDirectory({ ctx: evt }) {
 			const window = BrowserWindow.getAllWindows().find(
 				(win) => win.webContents.id === evt.sender.id,

--- a/packages/app/src/electron/requests/files/renderer.ts
+++ b/packages/app/src/electron/requests/files/renderer.ts
@@ -2,5 +2,5 @@ import { ipcRendererFetcher } from '../../utils/ipc/ipcRendererFetcher';
 
 import { filesChannel } from '.';
 
-export const { importNotes, selectDirectory, getUserDataPath, getResourcesPath } =
+export const { importNotes, selectDirectory, getUserDataPath } =
 	filesChannel.client(ipcRendererFetcher);

--- a/packages/app/src/electron/utils/files.ts
+++ b/packages/app/src/electron/utils/files.ts
@@ -18,9 +18,7 @@ export const joinPath = (root: string, ...segments: string[]) => {
 };
 
 export const getResourcesPath = (resourcePath?: string) => {
-	const rootPath = isDevMode()
-		? joinPath(app.getAppPath(), 'dist')
-		: process.resourcesPath;
+	const rootPath = joinPath(app.getAppPath(), 'dist');
 	return resourcePath ? joinPath(rootPath, resourcePath) : rootPath;
 };
 


### PR DESCRIPTION
Fixes #279 

The root cause of the bug is we returned incorrect path for resources directory in production build.
Now we return the path to a `dist` directory in both dev and production build.