### PR TITLE
feat: keep the timestamps for imported notes

### DIFF
--- a/packages/app/src/core/features/notes/controller/NotesController.test.ts
+++ b/packages/app/src/core/features/notes/controller/NotesController.test.ts
@@ -452,6 +452,7 @@ test('Batch notes updates', async () => {
 	]);
 
 	// Update with set current timestamps
+	const timeBeforeUpdate1 = Date.now();
 	await registry.updateBatch([
 		{ id: noteIds[0], text: '', title: '' },
 		{ id: noteIds[1], text: '', title: '' },
@@ -461,23 +462,23 @@ test('Batch notes updates', async () => {
 	const expectGreaterThanOrEqual = (expectedNumber: number) =>
 		expect.toSatisfy((value) => typeof value === 'number' && value >= expectedNumber);
 
-	const time1 = Date.now();
 	await expect(registry.getById(noteIds)).resolves.toMatchObject([
 		{
 			id: noteIds[0],
-			updatedTimestamp: expectGreaterThanOrEqual(time1),
+			updatedTimestamp: expectGreaterThanOrEqual(timeBeforeUpdate1),
 		},
 		{
 			id: noteIds[1],
-			updatedTimestamp: expectGreaterThanOrEqual(time1),
+			updatedTimestamp: expectGreaterThanOrEqual(timeBeforeUpdate1),
 		},
 		{
 			id: noteIds[2],
-			updatedTimestamp: expectGreaterThanOrEqual(time1),
+			updatedTimestamp: expectGreaterThanOrEqual(timeBeforeUpdate1),
 		},
 	]);
 
 	// Mixed update
+	const timeBeforeUpdate2 = Date.now();
 	await registry.updateBatch([
 		{ id: noteIds[0], updatedAt: 100, title: 'Updated to 100', text: '' },
 		{ id: noteIds[1], updatedAt: false, title: 'Timestamp is not changed', text: '' },
@@ -489,7 +490,6 @@ test('Batch notes updates', async () => {
 		},
 	]);
 
-	const time2 = Date.now();
 	await expect(registry.getById(noteIds)).resolves.toMatchObject([
 		{
 			id: noteIds[0],
@@ -498,14 +498,19 @@ test('Batch notes updates', async () => {
 		},
 		{
 			id: noteIds[1],
-			updatedTimestamp: expect.toSatisfy(
-				(value) => typeof value === 'number' && value >= time1 && value < time2,
-			),
+			updatedTimestamp: expect.toSatisfy((value) => {
+				expect(value).toBeGreaterThanOrEqual(timeBeforeUpdate1);
+				expect(value).toBeLessThanOrEqual(timeBeforeUpdate2);
+				return true;
+			}),
 			content: { title: 'Timestamp is not changed' },
 		},
 		{
 			id: noteIds[2],
-			updatedTimestamp: expectGreaterThanOrEqual(time2),
+			updatedTimestamp: expect.toSatisfy((value) => {
+				expect(value).toBeGreaterThanOrEqual(timeBeforeUpdate2);
+				return true;
+			}),
 			content: { title: 'Timestamp is set as current time' },
 		},
 	]);

--- a/packages/app/src/core/features/notes/controller/NotesController.test.ts
+++ b/packages/app/src/core/features/notes/controller/NotesController.test.ts
@@ -349,4 +349,164 @@ describe('Meta data control', () => {
 			},
 		]);
 	});
+
+	test('toggle note update time', async () => {
+		const { db, workspaceId } = getWorkspaceContext();
+		const registry = new NotesController(db, workspaceId);
+
+		// Create note
+		const noteId = await registry.add(
+			{ title: 'Title', text: 'Text' },
+			{ updatedAt: 1000 },
+		);
+		await expect(registry.getById([noteId])).resolves.toMatchObject([
+			{
+				id: noteId,
+				content: { title: 'Title', text: 'Text' },
+				updatedTimestamp: 1000,
+			},
+		]);
+
+		// Toggle snapshotting preferences
+		await registry.updateMeta([noteId], { updatedAt: 5000 });
+		await expect(registry.getById([noteId])).resolves.toMatchObject([
+			{
+				id: noteId,
+				content: { title: 'Title', text: 'Text' },
+				updatedTimestamp: 5000,
+			},
+		]);
+	});
+});
+
+const getWorkspaceContext = createWorkspaceContext();
+
+test('Batch notes updates', async () => {
+	const { db, workspaceId } = getWorkspaceContext();
+	const registry = new NotesController(db, workspaceId);
+
+	// Create notes
+	const noteIds = await Promise.all([
+		registry.add({ title: 'note#1', text: '' }, { updatedAt: 1000 }),
+		registry.add({ title: 'note#2', text: '' }, { updatedAt: 1000 }),
+		registry.add({ title: 'note#3', text: '' }, { updatedAt: 1000 }),
+	]);
+	await expect(registry.getById(noteIds)).resolves.toMatchObject([
+		{
+			id: noteIds[0],
+			updatedTimestamp: 1000,
+		},
+		{
+			id: noteIds[1],
+			updatedTimestamp: 1000,
+		},
+		{
+			id: noteIds[2],
+			updatedTimestamp: 1000,
+		},
+	]);
+	// await expect(registry.query({ sort: { by: 'updatedAt', order: 'asc' } })).resolves.toStrictEqual(noteIds);
+
+	// Update timestamps
+	await registry.updateBatch([
+		{ id: noteIds[2], updatedAt: 300, text: '', title: '' },
+		{ id: noteIds[1], updatedAt: 200, text: '', title: '' },
+		{ id: noteIds[0], updatedAt: 100, text: '', title: '' },
+	]);
+
+	await expect(registry.getById(noteIds)).resolves.toMatchObject([
+		{
+			id: noteIds[0],
+			updatedTimestamp: 100,
+		},
+		{
+			id: noteIds[1],
+			updatedTimestamp: 200,
+		},
+		{
+			id: noteIds[2],
+			updatedTimestamp: 300,
+		},
+	]);
+
+	// Update with no change a timestamps
+	await registry.updateBatch([
+		{ id: noteIds[2], updatedAt: false, text: '', title: '' },
+		{ id: noteIds[1], updatedAt: false, text: '', title: '' },
+		{ id: noteIds[0], updatedAt: false, text: '', title: '' },
+	]);
+
+	await expect(registry.getById(noteIds)).resolves.toMatchObject([
+		{
+			id: noteIds[0],
+			updatedTimestamp: 100,
+		},
+		{
+			id: noteIds[1],
+			updatedTimestamp: 200,
+		},
+		{
+			id: noteIds[2],
+			updatedTimestamp: 300,
+		},
+	]);
+
+	// Update with set current timestamps
+	await registry.updateBatch([
+		{ id: noteIds[0], text: '', title: '' },
+		{ id: noteIds[1], text: '', title: '' },
+		{ id: noteIds[2], text: '', title: '' },
+	]);
+
+	const expectGreaterThanOrEqual = (expectedNumber: number) =>
+		expect.toSatisfy((value) => typeof value === 'number' && value >= expectedNumber);
+
+	const time1 = Date.now();
+	await expect(registry.getById(noteIds)).resolves.toMatchObject([
+		{
+			id: noteIds[0],
+			updatedTimestamp: expectGreaterThanOrEqual(time1),
+		},
+		{
+			id: noteIds[1],
+			updatedTimestamp: expectGreaterThanOrEqual(time1),
+		},
+		{
+			id: noteIds[2],
+			updatedTimestamp: expectGreaterThanOrEqual(time1),
+		},
+	]);
+
+	// Mixed update
+	await registry.updateBatch([
+		{ id: noteIds[0], updatedAt: 100, title: 'Updated to 100', text: '' },
+		{ id: noteIds[1], updatedAt: false, title: 'Timestamp is not changed', text: '' },
+		{
+			id: noteIds[2],
+			updatedAt: undefined,
+			title: 'Timestamp is set as current time',
+			text: '',
+		},
+	]);
+
+	const time2 = Date.now();
+	await expect(registry.getById(noteIds)).resolves.toMatchObject([
+		{
+			id: noteIds[0],
+			updatedTimestamp: 100,
+			content: { title: 'Updated to 100' },
+		},
+		{
+			id: noteIds[1],
+			updatedTimestamp: expect.toSatisfy(
+				(value) => typeof value === 'number' && value >= time1 && value < time2,
+			),
+			content: { title: 'Timestamp is not changed' },
+		},
+		{
+			id: noteIds[2],
+			updatedTimestamp: expectGreaterThanOrEqual(time2),
+			content: { title: 'Timestamp is set as current time' },
+		},
+	]);
 });

--- a/packages/app/src/core/features/notes/controller/NotesController.ts
+++ b/packages/app/src/core/features/notes/controller/NotesController.ts
@@ -9,6 +9,7 @@ import { FlexSearchIndex } from '../../../database/flexsearch/FlexSearchIndex';
 
 import { INote, INoteContent, NoteId } from '..';
 import {
+	ControlledNoteMeta,
 	INotesController,
 	NoteContentUpdateInfo,
 	NoteMeta,
@@ -316,7 +317,10 @@ export class NotesController implements INotesController {
 		return this.getById(ids);
 	}
 
-	public async add(note: INoteContent, meta?: Partial<NoteMeta>): Promise<NoteId> {
+	public async add(
+		note: INoteContent,
+		{ updatedAt, ...meta }: ControlledNoteMeta = {},
+	): Promise<NoteId> {
 		const creationTime = Date.now();
 
 		// Insert data
@@ -333,7 +337,7 @@ export class NotesController implements INotesController {
 				note.title,
 				note.text,
 				creationTime,
-				creationTime,
+				updatedAt ?? creationTime,
 				...metaEntries.map(([_key, value]) => value),
 			])}) RETURNING id`,
 			z.object({ id: z.string() }).transform(({ id }) => id),
@@ -349,18 +353,33 @@ export class NotesController implements INotesController {
 	public async updateBatch(notes: NoteContentUpdateInfo[]) {
 		if (notes.length === 0) return;
 
+		const now = Date.now();
 		const db = wrapSQLite(this.db);
 		await db.query(
-			qb.sql`WITH updates(id, title, text) AS (
-				VALUES ${qb.set(notes.map(({ id, title, text }) => qb.values([id, title, text]).withParenthesis()))}
+			qb.sql`WITH updates(id, title, text, updated_at) AS (
+				VALUES ${qb.set(
+					notes.map(({ id, title, text, updatedAt }) =>
+						qb
+							.values([
+								id,
+								title,
+								text,
+								updatedAt === false ? null : (updatedAt ?? now),
+							])
+							.withParenthesis(),
+					),
+				)}
 			)
-			UPDATE notes
+			UPDATE notes AS n
 			SET
 				title = updates.title,
 				text = updates.text,
-				updated_at = ${Date.now()}
+				updated_at = CASE
+					WHEN updates.updated_at IS NULL THEN n.updated_at
+					ELSE updates.updated_at
+				END
 			FROM updates
-			WHERE notes.id = updates.id AND workspace_id=${this.workspace}`,
+			WHERE n.id = updates.id AND workspace_id=${this.workspace}`,
 		);
 	}
 
@@ -382,13 +401,16 @@ export class NotesController implements INotesController {
 		}
 	}
 
-	public async updateMeta(ids: NoteId[], meta: Partial<NoteMeta>): Promise<void> {
+	public async updateMeta(
+		ids: NoteId[],
+		{ updatedAt, ...meta }: ControlledNoteMeta = {},
+	): Promise<void> {
 		if (ids.length === 0) return;
 
 		const db = wrapSQLite(this.db);
 
 		await db.query(
-			qb.sql`UPDATE notes SET ${qb.values(formatNoteMeta(meta))}
+			qb.sql`UPDATE notes SET ${qb.values({ ...formatNoteMeta(meta), ...(updatedAt ? { updated_at: updatedAt } : {}) })}
 				WHERE workspace_id=${this.workspace} AND id IN (${qb.values(ids)})`,
 		);
 	}

--- a/packages/app/src/core/features/notes/controller/NotesController.ts
+++ b/packages/app/src/core/features/notes/controller/NotesController.ts
@@ -410,7 +410,7 @@ export class NotesController implements INotesController {
 		const db = wrapSQLite(this.db);
 
 		await db.query(
-			qb.sql`UPDATE notes SET ${qb.values({ ...formatNoteMeta(meta), ...(updatedAt ? { updated_at: updatedAt } : {}) })}
+			qb.sql`UPDATE notes SET ${qb.values({ ...formatNoteMeta(meta), ...(updatedAt !== undefined ? { updated_at: updatedAt } : {}) })}
 				WHERE workspace_id=${this.workspace} AND id IN (${qb.values(ids)})`,
 		);
 	}

--- a/packages/app/src/core/features/notes/controller/index.ts
+++ b/packages/app/src/core/features/notes/controller/index.ts
@@ -10,7 +10,10 @@ export type NoteMeta = {
 
 export type NoteSortField = 'id' | 'createdAt' | 'updatedAt' | 'deletedAt';
 
-export type NoteContentUpdateInfo = { id: NoteId } & INoteContent;
+export type NoteContentUpdateInfo = {
+	id: NoteId;
+	updatedAt?: number | false;
+} & INoteContent;
 
 type DateRange = {
 	/**
@@ -74,6 +77,8 @@ export type NotesControllerFetchOptions = {
 	};
 };
 
+export type ControlledNoteMeta = Partial<NoteMeta> & { updatedAt?: number };
+
 /**
  * Notes controller interface
  */
@@ -101,7 +106,7 @@ export interface INotesController {
 	/**
 	 * Create note and return unique id of new note
 	 */
-	add(note: INoteContent, meta?: Partial<NoteMeta>): Promise<NoteId>;
+	add(note: INoteContent, meta?: Partial<ControlledNoteMeta>): Promise<NoteId>;
 
 	/**
 	 * Update note by unique id
@@ -118,7 +123,7 @@ export interface INotesController {
 	/**
 	 * Update note meta information
 	 */
-	updateMeta(ids: NoteId[], meta: Partial<NoteMeta>): Promise<void>;
+	updateMeta(ids: NoteId[], meta: Partial<ControlledNoteMeta>): Promise<void>;
 
 	/**
 	 * Deletes all notes with specified ids

--- a/packages/app/src/core/storage/interop/import/NotesImporter.test.ts
+++ b/packages/app/src/core/storage/interop/import/NotesImporter.test.ts
@@ -759,6 +759,8 @@ describe('Import respects meta info', () => {
 
 	test('Update timestamps is preserved', async () => {
 		const deps = getAppContext();
+
+		const timeBeforeImport = Date.now();
 		await new NotesImporter(deps, {
 			ignorePaths: ['/_resources'],
 			noteExtensions: ['.md', '.mdx'],
@@ -797,6 +799,24 @@ describe('Import respects meta info', () => {
 						}) +
 						'---\nHello world!',
 				),
+				'/note-5.md': createTextBuffer(
+					'---\n' +
+						yamlStringify({
+							title: 'Note #5',
+							created: 'Some invalid data',
+						}) +
+						'---\nHello world!',
+				),
+				'/note-6.md': createTextBuffer(
+					'---\n' +
+						yamlStringify({
+							title: 'Note #6',
+							updatedAt: 'Some invalid data',
+							createdAt: 'Some invalid data',
+							created: '01.01.2008 12:00',
+						}) +
+						'---\nUpdate time fallback to any valid time',
+				),
 			}),
 		);
 
@@ -828,6 +848,21 @@ describe('Import respects meta info', () => {
 				updatedTimestamp: new Date('11.11.2007 11:22').getTime(),
 				content: {
 					title: 'Note #4',
+				},
+			},
+			{
+				content: {
+					title: 'Note #5',
+				},
+				updatedTimestamp: expect.toSatisfy((value) => {
+					expect(value).toBeGreaterThanOrEqual(timeBeforeImport);
+					return true;
+				}),
+			},
+			{
+				updatedTimestamp: new Date('01.01.2008 12:00').getTime(),
+				content: {
+					title: 'Note #6',
 				},
 			},
 		]);

--- a/packages/app/src/core/storage/interop/import/NotesImporter.test.ts
+++ b/packages/app/src/core/storage/interop/import/NotesImporter.test.ts
@@ -1,3 +1,4 @@
+import { stringify as yamlStringify } from 'yaml';
 import { AttachmentsController } from '@core/features/attachments/AttachmentsController';
 import { createFileManagerMock } from '@core/features/files/__tests__/mocks/createFileManagerMock';
 import { FilesController } from '@core/features/files/FilesController';
@@ -726,5 +727,109 @@ describe('Import interruptions', () => {
 				batchSize: 1,
 			}),
 		).rejects.toThrowError('Database');
+	});
+});
+
+describe('Import respects meta info', () => {
+	const fileManager = createFileManagerMock();
+	const getWorkspaceContext = createWorkspaceContext();
+	const getAppContext = createTestContext(
+		async () => {
+			const { db } = getWorkspaceContext();
+
+			const workspaceId = await createWorkspaceId(db);
+
+			const notesRegistry = new NotesController(db, workspaceId);
+			const noteVersions = new NoteVersions(db, workspaceId);
+			const tagsRegistry = new TagsController(db, workspaceId);
+
+			const attachmentsRegistry = new AttachmentsController(db, workspaceId);
+			const filesRegistry = new FilesController(db, fileManager, workspaceId);
+
+			return {
+				filesRegistry,
+				notesRegistry,
+				noteVersions,
+				attachmentsRegistry,
+				tagsRegistry,
+			};
+		},
+		{ hook: beforeEach },
+	);
+
+	test('Update timestamps is preserved', async () => {
+		const deps = getAppContext();
+		await new NotesImporter(deps, {
+			ignorePaths: ['/_resources'],
+			noteExtensions: ['.md', '.mdx'],
+			convertPathToTag: 'always',
+		}).import(
+			createFileManagerMock({
+				'/note-1.md': createTextBuffer(
+					'---\n' +
+						yamlStringify({
+							title: 'Note #1',
+							updatedAt: '2025-01-27 10:43:40Z',
+						}) +
+						'---\nHello world!',
+				),
+				'/note-2.md': createTextBuffer(
+					'---\n' +
+						yamlStringify({
+							title: 'Note #2',
+							updatedAt: 123456789,
+						}) +
+						'---\nHello world!',
+				),
+				'/note-3.md': createTextBuffer(
+					'---\n' +
+						yamlStringify({
+							title: 'Note #3',
+							updated: '11/11/2007',
+						}) +
+						'---\nHello world!',
+				),
+				'/note-4.md': createTextBuffer(
+					'---\n' +
+						yamlStringify({
+							title: 'Note #4',
+							created: '11.11.2007 11:22',
+						}) +
+						'---\nHello world!',
+				),
+			}),
+		);
+
+		const { notesRegistry } = deps;
+		await expect(
+			notesRegistry
+				.query({ sort: { by: 'createdAt' } })
+				.then((ids) => notesRegistry.getById(ids)),
+		).resolves.toMatchObject([
+			{
+				updatedTimestamp: new Date('2025-01-27 10:43:40Z').getTime(),
+				content: {
+					title: 'Note #1',
+				},
+			},
+			{
+				updatedTimestamp: new Date(123456789).getTime(),
+				content: {
+					title: 'Note #2',
+				},
+			},
+			{
+				updatedTimestamp: new Date('11/11/2007').getTime(),
+				content: {
+					title: 'Note #3',
+				},
+			},
+			{
+				updatedTimestamp: new Date('11.11.2007 11:22').getTime(),
+				content: {
+					title: 'Note #4',
+				},
+			},
+		]);
 	});
 });

--- a/packages/app/src/core/storage/interop/import/index.ts
+++ b/packages/app/src/core/storage/interop/import/index.ts
@@ -75,6 +75,39 @@ const RawNoteMetaScheme = z
 			.transform((tags) => tags.map((tag) => tag.trim()).filter(Boolean))
 			.optional()
 			.catch(undefined),
+		updated: z.coerce
+			.date()
+			.transform((date) => date.getTime())
+			.or(z.number())
+			.optional(),
+		updatedAt: z.coerce
+			.date()
+			.transform((date) => date.getTime())
+			.or(z.number())
+			.optional(),
+		created: z.coerce
+			.date()
+			.transform((date) => date.getTime())
+			.or(z.number())
+			.optional(),
+		createdAt: z.coerce
+			.date()
+			.transform((date) => date.getTime())
+			.or(z.number())
+			.optional(),
+	})
+	.transform(({ title, tags, updated, updatedAt, created, createdAt }) => {
+		return {
+			title,
+			tags,
+			updatedAt: updatedAt ?? updated,
+			createdAt: createdAt ?? created,
+		} as {
+			title?: string;
+			tags?: string[];
+			updatedAt?: number;
+			createdAt?: number;
+		};
 	})
 	.catch({});
 
@@ -220,7 +253,7 @@ export class NotesImporter {
 					// TODO: do not change original note markup (like bullet points marker style, escaping chars)
 					text: markdownProcessor.stringify(mdTree),
 				},
-				{ isVisible: false },
+				{ isVisible: false, updatedAt: noteMeta.updatedAt ?? noteMeta.createdAt },
 			);
 
 			// Attach tags
@@ -330,6 +363,7 @@ export class NotesImporter {
 							id: note.id,
 							...note.content,
 							text: markdownProcessor.stringify(noteTree),
+							updatedAt: false,
 						});
 
 						// Attach files

--- a/packages/app/src/core/storage/interop/import/index.ts
+++ b/packages/app/src/core/storage/interop/import/index.ts
@@ -66,6 +66,13 @@ const createNotifier = ({
 	};
 };
 
+const optionalDateValue = z.coerce
+	.date()
+	.transform((date) => date.getTime())
+	.or(z.number())
+	.optional()
+	.catch(undefined);
+
 const RawNoteMetaScheme = z
 	.object({
 		title: z.string().trim().min(1).optional().catch(undefined),
@@ -75,26 +82,10 @@ const RawNoteMetaScheme = z
 			.transform((tags) => tags.map((tag) => tag.trim()).filter(Boolean))
 			.optional()
 			.catch(undefined),
-		updated: z.coerce
-			.date()
-			.transform((date) => date.getTime())
-			.or(z.number())
-			.optional(),
-		updatedAt: z.coerce
-			.date()
-			.transform((date) => date.getTime())
-			.or(z.number())
-			.optional(),
-		created: z.coerce
-			.date()
-			.transform((date) => date.getTime())
-			.or(z.number())
-			.optional(),
-		createdAt: z.coerce
-			.date()
-			.transform((date) => date.getTime())
-			.or(z.number())
-			.optional(),
+		updated: optionalDateValue,
+		updatedAt: optionalDateValue,
+		created: optionalDateValue,
+		createdAt: optionalDateValue,
 	})
 	.transform(({ title, tags, updated, updatedAt, created, createdAt }) => {
 		return {

--- a/packages/app/src/features/MainScreen/NotesListPanel/NotesList.tsx
+++ b/packages/app/src/features/MainScreen/NotesListPanel/NotesList.tsx
@@ -158,7 +158,7 @@ export const NotesList: FC<NotesListProps> = () => {
 									/>
 								);
 
-							const date = note.createdTimestamp ?? note.updatedTimestamp;
+							const date = note.updatedTimestamp ?? note.createdTimestamp;
 
 							// TODO: get preview text from DB as prepared value
 							// TODO: show attachments


### PR DESCRIPTION
Closes #294

Changes
- Import now set update time from the frontmatter meta
- NotesController now let us set the update time
- Fixed note preview component. Now we show time of last update instead of creation time

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Explicit control over note updated timestamps when creating or updating notes.
  * Importer preserves and maps frontmatter timestamps into note metadata.
  * Notes list displays last-updated timestamp before created date.

* **Tests**
  * Expanded tests covering single and batch timestamp behaviors and import timestamp parsing.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/DeepinkApp/deepink/pull/295?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->