### PR TITLE
feat: add options to close many tabs

### DIFF
--- a/packages/app/src/__tests__/utils/redux.ts
+++ b/packages/app/src/__tests__/utils/redux.ts
@@ -1,0 +1,60 @@
+import { INote } from '@core/features/notes';
+import { configureStore } from '@reduxjs/toolkit';
+
+import { defaultSettings, settingsSlice } from '../../state/redux/settings/settings';
+import { RootState } from '../../state/redux/store';
+import { selectWorkspaceRootSafe } from '../../state/redux/vaults/utils';
+import {
+	createWorkspaceObject,
+	defaultVaultConfig,
+	selectWorkspace,
+	vaultsSlice,
+} from '../../state/redux/vaults/vaults';
+
+export const mockNoteObject = (id: string) => ({ id }) as unknown as INote;
+
+export function createTestStore() {
+	const TEST_VAULT_NAME = 'test-vault-1';
+	const TEST_WORKSPACE_NAME = 'test-workspace-1';
+	const workspaceScope = {
+		vaultId: TEST_VAULT_NAME,
+		workspaceId: TEST_WORKSPACE_NAME,
+	};
+
+	const store = configureStore({
+		reducer: {
+			settings: settingsSlice.reducer,
+			vaults: vaultsSlice.reducer,
+		},
+		preloadedState: {
+			settings: defaultSettings,
+			vaults: {
+				activeVault: TEST_VAULT_NAME,
+				vaults: {
+					[TEST_VAULT_NAME]: {
+						activeWorkspace: TEST_WORKSPACE_NAME,
+						workspaces: {
+							[TEST_WORKSPACE_NAME]: createWorkspaceObject({
+								id: TEST_WORKSPACE_NAME,
+								name: TEST_WORKSPACE_NAME,
+								newNoteTemplate: '',
+							}),
+						},
+						config: defaultVaultConfig,
+					},
+				},
+			},
+		} satisfies RootState,
+	});
+
+	return {
+		store,
+		workspaceScope,
+		selectors: {
+			workspace: () =>
+				selectWorkspaceRootSafe(
+					selectWorkspace(workspaceScope)(store.getState()),
+				),
+		},
+	};
+}

--- a/packages/app/src/features/NotesContainer/NoteContextMenu/index.ts
+++ b/packages/app/src/features/NotesContainer/NoteContextMenu/index.ts
@@ -5,4 +5,10 @@ export enum NoteActions {
 	DELETE_TO_BIN = 'deleteToBin',
 	DELETE_PERMANENTLY = 'deletePermanently',
 	RESTORE_FROM_BIN = 'restoreFromBin',
+
+	CLOSE = 'CLOSE',
+	CLOSE_ALL = 'CLOSE_ALL',
+	CLOSE_OTHER_NOTES = 'CLOSE_OTHER_NOTES',
+	CLOSE_TO_THE_RIGHT = 'CLOSE_TO_THE_RIGHT',
+	CLOSE_TO_THE_LEFT = 'CLOSE_TO_THE_LEFT',
 }

--- a/packages/app/src/features/NotesContainer/NoteContextMenu/useNoteContextMenu.ts
+++ b/packages/app/src/features/NotesContainer/NoteContextMenu/useNoteContextMenu.ts
@@ -8,16 +8,20 @@ import { GLOBAL_COMMANDS } from '@hooks/commands';
 import { useCommand } from '@hooks/commands/useCommand';
 import { ContextMenuCallback } from '@hooks/useContextMenu';
 import { useShowNoteContextMenu } from '@hooks/useShowNoteContextMenu';
-import { useVaultSelector } from '@state/redux/vaults/hooks';
+import { useAppDispatch } from '@state/redux/hooks';
+import { useVaultSelector, useWorkspaceActions } from '@state/redux/vaults/hooks';
 import { selectDeletionConfig } from '@state/redux/vaults/selectors/vault';
 
 import { NoteActions } from '.';
 
-export const useNoteContextMenu = () => {
+export const useNoteContextMenu = (context?: 'tabs' | 'notes-list') => {
 	const telemetry = useTelemetryTracker();
 	const { t } = useTranslation(LOCALE_NAMESPACE.menu, { keyPrefix: 'note' });
 
 	const deletionConfig = useVaultSelector(selectDeletionConfig);
+
+	const dispatch = useAppDispatch();
+	const workspaceActions = useWorkspaceActions();
 
 	const runCommand = useCommand();
 
@@ -55,13 +59,38 @@ export const useNoteContextMenu = () => {
 				[NoteActions.EXPORT]: (noteId: string) => {
 					runCommand(GLOBAL_COMMANDS.EXPORT_NOTE, { noteId });
 				},
+				[NoteActions.CLOSE]: (noteId: string) => {
+					dispatch(
+						workspaceActions.closeNotes({ query: { noteIds: [noteId] } }),
+					);
+				},
+				[NoteActions.CLOSE_ALL]: () => {
+					dispatch(workspaceActions.closeNotes({ query: { all: true } }));
+				},
+				[NoteActions.CLOSE_OTHER_NOTES]: (noteId: string) => {
+					dispatch(
+						workspaceActions.closeNotes({
+							query: { all: true, exclude: [noteId] },
+						}),
+					);
+				},
+				[NoteActions.CLOSE_TO_THE_LEFT]: (noteId: string) => {
+					dispatch(
+						workspaceActions.closeNotes({ query: { beforeNoteId: noteId } }),
+					);
+				},
+				[NoteActions.CLOSE_TO_THE_RIGHT]: (noteId: string) => {
+					dispatch(
+						workspaceActions.closeNotes({ query: { afterNoteId: noteId } }),
+					);
+				},
 			};
 
 			if (action in actionsMap) {
 				actionsMap[action](id);
 			}
 		},
-		[telemetry, runCommand],
+		[telemetry, runCommand, dispatch, workspaceActions],
 	);
 
 	const showMenu = useShowNoteContextMenu(noteContextMenuCallback);
@@ -69,6 +98,25 @@ export const useNoteContextMenu = () => {
 	return useCallback(
 		(note: INote, point: { x: number; y: number }) => {
 			showMenu(note.id, point, [
+				...(context === 'tabs'
+					? [
+							{ id: NoteActions.CLOSE, label: t('close') },
+							{
+								id: NoteActions.CLOSE_OTHER_NOTES,
+								label: t('closeOthers'),
+							},
+							{
+								id: NoteActions.CLOSE_TO_THE_LEFT,
+								label: t('closeToTheLeft'),
+							},
+							{
+								id: NoteActions.CLOSE_TO_THE_RIGHT,
+								label: t('closeToTheRight'),
+							},
+							{ id: NoteActions.CLOSE_ALL, label: t('closeAll') },
+						]
+					: []),
+
 				...(note.isDeleted
 					? [{ id: NoteActions.RESTORE_FROM_BIN, label: t('restoreFromBin') }]
 					: []),
@@ -95,6 +143,6 @@ export const useNoteContextMenu = () => {
 					: { id: NoteActions.DELETE_TO_BIN, label: t('deleteToBin') },
 			]);
 		},
-		[deletionConfig.permanentDeletion, showMenu, t],
+		[context, deletionConfig.permanentDeletion, showMenu, t],
 	);
 };

--- a/packages/app/src/features/NotesContainer/NoteContextMenu/useNoteContextMenu.ts
+++ b/packages/app/src/features/NotesContainer/NoteContextMenu/useNoteContextMenu.ts
@@ -99,22 +99,23 @@ export const useNoteContextMenu = (context?: 'tabs' | 'notes-list') => {
 		(note: INote, point: { x: number; y: number }) => {
 			showMenu(note.id, point, [
 				...(context === 'tabs'
-					? [
-							{ id: NoteActions.CLOSE, label: t('close') },
+					? ([
+							{ id: NoteActions.CLOSE, label: t('tab.close') },
 							{
 								id: NoteActions.CLOSE_OTHER_NOTES,
-								label: t('closeOthers'),
+								label: t('tab.closeOthers'),
 							},
 							{
 								id: NoteActions.CLOSE_TO_THE_LEFT,
-								label: t('closeToTheLeft'),
+								label: t('tab.closeToTheLeft'),
 							},
 							{
 								id: NoteActions.CLOSE_TO_THE_RIGHT,
-								label: t('closeToTheRight'),
+								label: t('tab.closeToTheRight'),
 							},
-							{ id: NoteActions.CLOSE_ALL, label: t('closeAll') },
-						]
+							{ id: NoteActions.CLOSE_ALL, label: t('tab.closeAll') },
+							{ type: 'separator' },
+						] as const)
 					: []),
 
 				...(note.isDeleted

--- a/packages/app/src/features/NotesContainer/OpenedNotesPanel.tsx
+++ b/packages/app/src/features/NotesContainer/OpenedNotesPanel.tsx
@@ -27,7 +27,7 @@ export const OpenedNotesPanel: FC<TopBarProps> = ({
 	onPick,
 }) => {
 	const { t } = useTranslation(LOCALE_NAMESPACE.features);
-	const openNoteContextMenu = useNoteContextMenu();
+	const openNoteContextMenu = useNoteContextMenu('tabs');
 
 	const existsTabs = useMemo(
 		() => tabs.filter((noteId) => notes.some((note) => note.id === noteId)),

--- a/packages/app/src/locales/ar/menu.json
+++ b/packages/app/src/locales/ar/menu.json
@@ -23,7 +23,14 @@
 		"copyMarkdownLink": "نسخ رابط Markdown",
 		"deletePermanently": "حذف نهائي",
 		"restoreFromBin": "استعادة من المهملات",
-		"deleteToBin": "نقل إلى المهملات"
+		"deleteToBin": "نقل إلى المهملات",
+		"tab": {
+			"close": "إغلاق",
+			"closeOthers": "إغلاق التبويبات الأخرى",
+			"closeToTheLeft": "إغلاق التبويبات على اليسار",
+			"closeToTheRight": "إغلاق التبويبات على اليمين",
+			"closeAll": "إغلاق الكل"
+		}
 	},
 	"tag": {
 		"addNestedTag": "إنشاء تسلسل وسوم...",

--- a/packages/app/src/locales/bg/menu.json
+++ b/packages/app/src/locales/bg/menu.json
@@ -23,7 +23,14 @@
 		"copyMarkdownLink": "Копирай Markdown линк",
 		"deletePermanently": "Изтриване завинаги",
 		"restoreFromBin": "Възстановяване от кошчето",
-		"deleteToBin": "Премести в кошчето"
+		"deleteToBin": "Премести в кошчето",
+		"tab": {
+			"close": "Затвори",
+			"closeOthers": "Затвори останалите",
+			"closeToTheLeft": "Затвори табовете вляво",
+			"closeToTheRight": "Затвори табовете вдясно",
+			"closeAll": "Затвори всички"
+		}
 	},
 	"tag": {
 		"addNestedTag": "Създаване на йерархия от тагове...",

--- a/packages/app/src/locales/ca/menu.json
+++ b/packages/app/src/locales/ca/menu.json
@@ -23,7 +23,14 @@
 		"copyMarkdownLink": "Copiar enllaç Markdown",
 		"deletePermanently": "Eliminar permanentment",
 		"restoreFromBin": "Restaurar de la paperera",
-		"deleteToBin": "Moure a la paperera"
+		"deleteToBin": "Moure a la paperera",
+		"tab": {
+			"close": "Tancar",
+			"closeOthers": "Tancar les altres",
+			"closeToTheLeft": "Tancar les pestanyes de l'esquerra",
+			"closeToTheRight": "Tancar les pestanyes de la dreta",
+			"closeAll": "Tancar-les totes"
+		}
 	},
 	"tag": {
 		"addNestedTag": "Crear jerarquia de etiquetes...",

--- a/packages/app/src/locales/cs/menu.json
+++ b/packages/app/src/locales/cs/menu.json
@@ -23,7 +23,14 @@
 		"copyMarkdownLink": "Kopírovat Markdown odkaz",
 		"deletePermanently": "Trvale smazat",
 		"restoreFromBin": "Obnovit ze koše",
-		"deleteToBin": "Přesunout do koše"
+		"deleteToBin": "Přesunout do koše",
+		"tab": {
+			"close": "Zavřít",
+			"closeOthers": "Zavřít ostatní",
+			"closeToTheLeft": "Zavřít karty vlevo",
+			"closeToTheRight": "Zavřít karty vpravo",
+			"closeAll": "Zavřít vše"
+		}
 	},
 	"tag": {
 		"addNestedTag": "Vytvořit hierarchii tagů...",

--- a/packages/app/src/locales/da/menu.json
+++ b/packages/app/src/locales/da/menu.json
@@ -23,7 +23,14 @@
 		"copyMarkdownLink": "Kopiér Markdown-link",
 		"deletePermanently": "Slet permanent",
 		"restoreFromBin": "Gendan fra papirkurv",
-		"deleteToBin": "Flyt til papirkurv"
+		"deleteToBin": "Flyt til papirkurv",
+		"tab": {
+			"close": "Luk",
+			"closeOthers": "Luk andre",
+			"closeToTheLeft": "Luk faner til venstre",
+			"closeToTheRight": "Luk faner til højre",
+			"closeAll": "Luk alle"
+		}
 	},
 	"tag": {
 		"addNestedTag": "Opret tag-hierarki...",

--- a/packages/app/src/locales/de/menu.json
+++ b/packages/app/src/locales/de/menu.json
@@ -23,7 +23,14 @@
 		"copyMarkdownLink": "Markdown-Link kopieren",
 		"deletePermanently": "Endgültig löschen",
 		"restoreFromBin": "Aus Papierkorb wiederherstellen",
-		"deleteToBin": "In Papierkorb verschieben"
+		"deleteToBin": "In Papierkorb verschieben",
+		"tab": {
+			"close": "Schließen",
+			"closeOthers": "Andere schließen",
+			"closeToTheLeft": "Links schließende Tabs",
+			"closeToTheRight": "Rechts schließende Tabs",
+			"closeAll": "Alle schließen"
+		}
 	},
 	"tag": {
 		"addNestedTag": "Tag-Hierarchie erstellen...",

--- a/packages/app/src/locales/el/menu.json
+++ b/packages/app/src/locales/el/menu.json
@@ -23,7 +23,14 @@
 		"copyMarkdownLink": "Αντιγραφή συνδέσμου Markdown",
 		"deletePermanently": "Μόνιμη διαγραφή",
 		"restoreFromBin": "Επαναφορά από το κάδο",
-		"deleteToBin": "Μεταφορά στον κάδο"
+		"deleteToBin": "Μεταφορά στον κάδο",
+		"tab": {
+			"close": "Κλείσιμο",
+			"closeOthers": "Κλείσιμο των άλλων",
+			"closeToTheLeft": "Κλείσιμο καρτελών αριστερά",
+			"closeToTheRight": "Κλείσιμο καρτελών δεξιά",
+			"closeAll": "Κλείσιμο όλων"
+		}
 	},
 	"tag": {
 		"addNestedTag": "Δημιουργία ιεραρχίας ετικετών...",

--- a/packages/app/src/locales/en/menu.json
+++ b/packages/app/src/locales/en/menu.json
@@ -23,7 +23,14 @@
 		"copyMarkdownLink": "Copy Markdown link",
 		"deletePermanently": "Delete permanently",
 		"restoreFromBin": "Restore from bin",
-		"deleteToBin": "Move to bin"
+		"deleteToBin": "Move to bin",
+		"tab": {
+			"close": "Close",
+			"closeOthers": "Close Others",
+			"closeToTheLeft": "Close Tabs to the Left",
+			"closeToTheRight": "Close Tabs to the Right",
+			"closeAll": "Close All"
+		}
 	},
 	"tag": {
 		"addNestedTag": "Create nested tag...",

--- a/packages/app/src/locales/es/menu.json
+++ b/packages/app/src/locales/es/menu.json
@@ -23,7 +23,14 @@
 		"copyMarkdownLink": "Copiar enlace Markdown",
 		"deletePermanently": "Eliminar permanentemente",
 		"restoreFromBin": "Restaurar de la papelera",
-		"deleteToBin": "Mover a la papelera"
+		"deleteToBin": "Mover a la papelera",
+		"tab": {
+			"close": "Cerrar",
+			"closeOthers": "Cerrar otras",
+			"closeToTheLeft": "Cerrar pestañas a la izquierda",
+			"closeToTheRight": "Cerrar pestañas a la derecha",
+			"closeAll": "Cerrar todas"
+		}
 	},
 	"tag": {
 		"addNestedTag": "Crear jerarquía de etiquetas...",

--- a/packages/app/src/locales/fa/menu.json
+++ b/packages/app/src/locales/fa/menu.json
@@ -23,7 +23,14 @@
 		"copyMarkdownLink": "کپی لینک مارک‌داون",
 		"deletePermanently": "حذف دائمی",
 		"restoreFromBin": "بازیابی از سطل زباله",
-		"deleteToBin": "انتقال به سطل زباله"
+		"deleteToBin": "انتقال به سطل زباله",
+		"tab": {
+			"close": "بستن",
+			"closeOthers": "بستن سایر تب‌ها",
+			"closeToTheLeft": "بستن تب‌های سمت چپ",
+			"closeToTheRight": "بستن تب‌های سمت راست",
+			"closeAll": "بستن همه"
+		}
 	},
 	"tag": {
 		"addNestedTag": "ایجاد سلسله‌مراتب برچسب...",

--- a/packages/app/src/locales/fi/menu.json
+++ b/packages/app/src/locales/fi/menu.json
@@ -23,7 +23,14 @@
 		"copyMarkdownLink": "Kopioi Markdown-linkki",
 		"deletePermanently": "Poista pysyvästi",
 		"restoreFromBin": "Palauta roskakorista",
-		"deleteToBin": "Siirrä roskakoriin"
+		"deleteToBin": "Siirrä roskakoriin",
+		"tab": {
+			"close": "Sulje",
+			"closeOthers": "Sulje muut",
+			"closeToTheLeft": "Sulje vasemmanpuoleiset välilehdet",
+			"closeToTheRight": "Sulje oikeanpuoleiset välilehdet",
+			"closeAll": "Sulje kaikki"
+		}
 	},
 	"tag": {
 		"addNestedTag": "Luo alatagi...",

--- a/packages/app/src/locales/fr/menu.json
+++ b/packages/app/src/locales/fr/menu.json
@@ -23,7 +23,14 @@
 		"copyMarkdownLink": "Copier le lien Markdown",
 		"deletePermanently": "Supprimer définitivement",
 		"restoreFromBin": "Restaurer de la corbeille",
-		"deleteToBin": "Placer dans la corbeille"
+		"deleteToBin": "Placer dans la corbeille",
+		"tab": {
+			"close": "Fermer",
+			"closeOthers": "Fermer les autres",
+			"closeToTheLeft": "Fermer les onglets à gauche",
+			"closeToTheRight": "Fermer les onglets à droite",
+			"closeAll": "Tout fermer"
+		}
 	},
 	"tag": {
 		"addNestedTag": "Créer une hiérarchie de tags...",

--- a/packages/app/src/locales/he/menu.json
+++ b/packages/app/src/locales/he/menu.json
@@ -23,7 +23,14 @@
 		"copyMarkdownLink": "העתק קישור Markdown",
 		"deletePermanently": "מחיקה לצמיתות",
 		"restoreFromBin": "שחזור מהסל",
-		"deleteToBin": "העברה לסל"
+		"deleteToBin": "העברה לסל",
+		"tab": {
+			"close": "סגור",
+			"closeOthers": "סגור אחרים",
+			"closeToTheLeft": "סגור לשמאל",
+			"closeToTheRight": "סגור לימין",
+			"closeAll": "סגור הכל"
+		}
 	},
 	"tag": {
 		"addNestedTag": "יצירת היררכיית תגיות...",

--- a/packages/app/src/locales/hi/menu.json
+++ b/packages/app/src/locales/hi/menu.json
@@ -23,7 +23,14 @@
 		"copyMarkdownLink": "मार्कडाउन लिंक कॉपी करें",
 		"deletePermanently": "स्थायी रूप से हटाएं",
 		"restoreFromBin": "बिन से वापस लाएं",
-		"deleteToBin": "बिन में डालें"
+		"deleteToBin": "बिन में डालें",
+		"tab": {
+			"close": "बंद करें",
+			"closeOthers": "अन्य बंद करें",
+			"closeToTheLeft": "बाईं ओर के टैब बंद करें",
+			"closeToTheRight": "दाईं ओर के टैब बंद करें",
+			"closeAll": "सभी बंद करें"
+		}
 	},
 	"tag": {
 		"addNestedTag": "टैग पदानुक्रम बनाएं...",

--- a/packages/app/src/locales/hu/menu.json
+++ b/packages/app/src/locales/hu/menu.json
@@ -23,7 +23,14 @@
 		"copyMarkdownLink": "Markdown link másolása",
 		"deletePermanently": "Végleges törlés",
 		"restoreFromBin": "Visszaállítás a kukából",
-		"deleteToBin": "Kukába helyezés"
+		"deleteToBin": "Kukába helyezés",
+		"tab": {
+			"close": "Bezárás",
+			"closeOthers": "Bezárás többi lap",
+			"closeToTheLeft": "Bezárás balra",
+			"closeToTheRight": "Bezárás jobbra",
+			"closeAll": "Összes bezárása"
+		}
 	},
 	"tag": {
 		"addNestedTag": "Címke hierarchia létrehozása...",

--- a/packages/app/src/locales/id/menu.json
+++ b/packages/app/src/locales/id/menu.json
@@ -23,7 +23,14 @@
 		"copyMarkdownLink": "Salin tautan Markdown",
 		"deletePermanently": "Hapus permanen",
 		"restoreFromBin": "Pulihkan dari tempat sampah",
-		"deleteToBin": "Pindahkan ke tempat sampah"
+		"deleteToBin": "Pindahkan ke tempat sampah",
+		"tab": {
+			"close": "Tutup",
+			"closeOthers": "Tutup Lainnya",
+			"closeToTheLeft": "Tutup Tab di Kiri",
+			"closeToTheRight": "Tutup Tab di Kanan",
+			"closeAll": "Tutup Semua"
+		}
 	},
 	"tag": {
 		"addNestedTag": "Buat hierarki tag...",

--- a/packages/app/src/locales/it/menu.json
+++ b/packages/app/src/locales/it/menu.json
@@ -23,7 +23,14 @@
 		"copyMarkdownLink": "Copia link Markdown",
 		"deletePermanently": "Elimina definitivamente",
 		"restoreFromBin": "Ripristina dal cestino",
-		"deleteToBin": "Sposta nel cestino"
+		"deleteToBin": "Sposta nel cestino",
+		"tab": {
+			"close": "Chiudi",
+			"closeOthers": "Chiudi altri",
+			"closeToTheLeft": "Chiudi schede a sinistra",
+			"closeToTheRight": "Chiudi schede a destra",
+			"closeAll": "Chiudi tutto"
+		}
 	},
 	"tag": {
 		"addNestedTag": "Crea gerarchia tag...",

--- a/packages/app/src/locales/ja/menu.json
+++ b/packages/app/src/locales/ja/menu.json
@@ -23,7 +23,14 @@
 		"copyMarkdownLink": "Markdownリンクをコピー",
 		"deletePermanently": "完全に削除",
 		"restoreFromBin": "ゴミ箱から復元",
-		"deleteToBin": "ゴミ箱へ移動"
+		"deleteToBin": "ゴミ箱へ移動",
+		"tab": {
+			"close": "閉じる",
+			"closeOthers": "他のタブを閉じる",
+			"closeToTheLeft": "左側のタブを閉じる",
+			"closeToTheRight": "右側のタブを閉じる",
+			"closeAll": "すべて閉じる"
+		}
 	},
 	"tag": {
 		"addNestedTag": "タグの階層を作成...",

--- a/packages/app/src/locales/ka/menu.json
+++ b/packages/app/src/locales/ka/menu.json
@@ -23,7 +23,14 @@
 		"copyMarkdownLink": "Markdown ბმულის კოპირება",
 		"deletePermanently": "სამუდამოდ წაშლა",
 		"restoreFromBin": "ნაგვისబుდისგან აღდგენა",
-		"deleteToBin": "ნაგვისబుდაში გადატანა"
+		"deleteToBin": "ნაგვისబుდაში გადატანა",
+		"tab": {
+			"close": "დახურვა",
+			"closeOthers": "სხვა ტაბების დახურვა",
+			"closeToTheLeft": "მარცხენა ტაბების დახურვა",
+			"closeToTheRight": "მარჯვენა ტაბების დახურვა",
+			"closeAll": "ყველას დახურვა"
+		}
 	},
 	"tag": {
 		"addNestedTag": "ტეგების იერარქიის შექმნა...",

--- a/packages/app/src/locales/ko/menu.json
+++ b/packages/app/src/locales/ko/menu.json
@@ -23,7 +23,14 @@
 		"copyMarkdownLink": "마크다운 링크 복사",
 		"deletePermanently": "영구 삭제",
 		"restoreFromBin": "휴지통에서 복원",
-		"deleteToBin": "휴지통으로 이동"
+		"deleteToBin": "휴지통으로 이동",
+		"tab": {
+			"close": "닫기",
+			"closeOthers": "다른 탭 닫기",
+			"closeToTheLeft": "왼쪽 탭 닫기",
+			"closeToTheRight": "오른쪽 탭 닫기",
+			"closeAll": "모든 탭 닫기"
+		}
 	},
 	"tag": {
 		"addNestedTag": "하위 태그 생성...",

--- a/packages/app/src/locales/nb/menu.json
+++ b/packages/app/src/locales/nb/menu.json
@@ -23,7 +23,14 @@
 		"copyMarkdownLink": "Kopier Markdown-lenke",
 		"deletePermanently": "Slett permanent",
 		"restoreFromBin": "Gjenopprett fra papirkurv",
-		"deleteToBin": "Flytt til papirkurv"
+		"deleteToBin": "Flytt til papirkurv",
+		"tab": {
+			"close": "Lukk",
+			"closeOthers": "Lukk andre",
+			"closeToTheLeft": "Lukk faner til venstre",
+			"closeToTheRight": "Lukk faner til høyre",
+			"closeAll": "Lukk alle"
+		}
 	},
 	"tag": {
 		"addNestedTag": "Opprett undertagg...",

--- a/packages/app/src/locales/nl/menu.json
+++ b/packages/app/src/locales/nl/menu.json
@@ -23,7 +23,14 @@
 		"copyMarkdownLink": "Markdown-link kopiëren",
 		"deletePermanently": "Permanent verwijderen",
 		"restoreFromBin": "Herstellen uit prullenbak",
-		"deleteToBin": "Verplaatsen naar prullenbak"
+		"deleteToBin": "Verplaatsen naar prullenbak",
+		"tab": {
+			"close": "Sluiten",
+			"closeOthers": "Andere sluiten",
+			"closeToTheLeft": "Tabbladen links sluiten",
+			"closeToTheRight": "Tabbladen rechts sluiten",
+			"closeAll": "Alles sluiten"
+		}
 	},
 	"tag": {
 		"addNestedTag": "Taghiërarchie maken...",

--- a/packages/app/src/locales/pl/menu.json
+++ b/packages/app/src/locales/pl/menu.json
@@ -23,7 +23,14 @@
 		"copyMarkdownLink": "Kopiuj link Markdown",
 		"deletePermanently": "Usuń na stałe",
 		"restoreFromBin": "Przywróć z kosza",
-		"deleteToBin": "Przenieś do kosza"
+		"deleteToBin": "Przenieś do kosza",
+		"tab": {
+			"close": "Zamknij",
+			"closeOthers": "Zamknij pozostałe",
+			"closeToTheLeft": "Zamknij karty po lewej",
+			"closeToTheRight": "Zamknij karty po prawej",
+			"closeAll": "Zamknij wszystkie"
+		}
 	},
 	"tag": {
 		"addNestedTag": "Dodaj tag w hierarchii...",

--- a/packages/app/src/locales/pt-BR/menu.json
+++ b/packages/app/src/locales/pt-BR/menu.json
@@ -23,7 +23,14 @@
 		"copyMarkdownLink": "Copiar link Markdown",
 		"deletePermanently": "Excluir permanentemente",
 		"restoreFromBin": "Restaurar da lixeira",
-		"deleteToBin": "Mover para a lixeira"
+		"deleteToBin": "Mover para a lixeira",
+		"tab": {
+			"close": "Fechar",
+			"closeOthers": "Fechar outras",
+			"closeToTheLeft": "Fechar abas à esquerda",
+			"closeToTheRight": "Fechar abas à direita",
+			"closeAll": "Fechar todas"
+		}
 	},
 	"tag": {
 		"addNestedTag": "Criar hierarquia de tags...",

--- a/packages/app/src/locales/pt-PT/menu.json
+++ b/packages/app/src/locales/pt-PT/menu.json
@@ -23,7 +23,14 @@
 		"copyMarkdownLink": "Copiar link Markdown",
 		"deletePermanently": "Eliminar permanentemente",
 		"restoreFromBin": "Restaurar do lixo",
-		"deleteToBin": "Mover para o lixo"
+		"deleteToBin": "Mover para o lixo",
+		"tab": {
+			"close": "Fechar",
+			"closeOthers": "Fechar outros",
+			"closeToTheLeft": "Fechar abas à esquerda",
+			"closeToTheRight": "Fechar abas à direita",
+			"closeAll": "Fechar tudo"
+		}
 	},
 	"tag": {
 		"addNestedTag": "Criar hierarquia de etiquetas...",

--- a/packages/app/src/locales/ro/menu.json
+++ b/packages/app/src/locales/ro/menu.json
@@ -23,7 +23,14 @@
 		"copyMarkdownLink": "Copiază link Markdown",
 		"deletePermanently": "Șterge definitiv",
 		"restoreFromBin": "Restabilește din coș",
-		"deleteToBin": "Mută în coș"
+		"deleteToBin": "Mută în coș",
+		"tab": {
+			"close": "Închide",
+			"closeOthers": "Închide celelalte",
+			"closeToTheLeft": "Închide tab-urile din stânga",
+			"closeToTheRight": "Închide tab-urile din dreapta",
+			"closeAll": "Închide tot"
+		}
 	},
 	"tag": {
 		"addNestedTag": "Creează ierarhie de etichete...",

--- a/packages/app/src/locales/ru/menu.json
+++ b/packages/app/src/locales/ru/menu.json
@@ -23,7 +23,14 @@
 		"copyMarkdownLink": "Скопировать ссылку Markdown",
 		"deletePermanently": "Удалить навсегда",
 		"restoreFromBin": "Восстановить из корзины",
-		"deleteToBin": "В корзину"
+		"deleteToBin": "В корзину",
+		"tab": {
+			"close": "Закрыть",
+			"closeOthers": "Закрыть остальные",
+			"closeToTheLeft": "Закрыть вкладки слева",
+			"closeToTheRight": "Закрыть вкладки справа",
+			"closeAll": "Закрыть все"
+		}
 	},
 	"tag": {
 		"addNestedTag": "Создать вложенный тег…",

--- a/packages/app/src/locales/sl/menu.json
+++ b/packages/app/src/locales/sl/menu.json
@@ -23,7 +23,14 @@
 		"copyMarkdownLink": "Kopiraj Markdown povezavo",
 		"deletePermanently": "Trajno izbriši",
 		"restoreFromBin": "Obnovi iz smetnjaka",
-		"deleteToBin": "Prevedi v smetnjak"
+		"deleteToBin": "Prevedi v smetnjak",
+		"tab": {
+			"close": "Zapri",
+			"closeOthers": "Zapri druge",
+			"closeToTheLeft": "Zapri tabe levo",
+			"closeToTheRight": "Zapri tabe desno",
+			"closeAll": "Zapri vse"
+		}
 	},
 	"tag": {
 		"addNestedTag": "Ustvari hierarhijo oznak...",

--- a/packages/app/src/locales/sr/menu.json
+++ b/packages/app/src/locales/sr/menu.json
@@ -23,7 +23,14 @@
 		"copyMarkdownLink": "Kopiraj Markdown link",
 		"deletePermanently": "Trajno obriši",
 		"restoreFromBin": "Vrati iz kante",
-		"deleteToBin": "Premesti u kantu"
+		"deleteToBin": "Premesti u kantu",
+		"tab": {
+			"close": "Zatvori",
+			"closeOthers": "Zatvori ostale",
+			"closeToTheLeft": "Zatvori tabove levo",
+			"closeToTheRight": "Zatvori tabove desno",
+			"closeAll": "Zatvori sve"
+		}
 	},
 	"tag": {
 		"addNestedTag": "Kreiraj hijerarhiju tagova...",

--- a/packages/app/src/locales/sv/menu.json
+++ b/packages/app/src/locales/sv/menu.json
@@ -23,7 +23,14 @@
 		"copyMarkdownLink": "Kopiera Markdown-länk",
 		"deletePermanently": "Ta bort permanent",
 		"restoreFromBin": "Återställ från papperskorgen",
-		"deleteToBin": "Flytta till papperskorgen"
+		"deleteToBin": "Flytta till papperskorgen",
+		"tab": {
+			"close": "Stäng",
+			"closeOthers": "Stäng andra",
+			"closeToTheLeft": "Stäng flikar till vänster",
+			"closeToTheRight": "Stäng flikar till höger",
+			"closeAll": "Stäng alla"
+		}
 	},
 	"tag": {
 		"addNestedTag": "Skapa tagghierarki...",

--- a/packages/app/src/locales/th/menu.json
+++ b/packages/app/src/locales/th/menu.json
@@ -23,7 +23,14 @@
 		"copyMarkdownLink": "คัดลอกลิงก์ Markdown",
 		"deletePermanently": "ลบถาวร",
 		"restoreFromBin": "กู้คืนจากถังขยะ",
-		"deleteToBin": "ย้ายไปถังขยะ"
+		"deleteToBin": "ย้ายไปถังขยะ",
+		"tab": {
+			"close": "ปิด",
+			"closeOthers": "ปิดแท็บอื่น",
+			"closeToTheLeft": "ปิดแท็บด้านซ้าย",
+			"closeToTheRight": "ปิดแท็บด้านขวา",
+			"closeAll": "ปิดทั้งหมด"
+		}
 	},
 	"tag": {
 		"addNestedTag": "สร้างลำดับแท็ก...",

--- a/packages/app/src/locales/tr/menu.json
+++ b/packages/app/src/locales/tr/menu.json
@@ -23,7 +23,14 @@
 		"copyMarkdownLink": "Markdown bağlantısını kopyala",
 		"deletePermanently": "Kalıcı olarak sil",
 		"restoreFromBin": "Çöp kutusundan geri yükle",
-		"deleteToBin": "Çöp kutusuna taşı"
+		"deleteToBin": "Çöp kutusuna taşı",
+		"tab": {
+			"close": "Kapat",
+			"closeOthers": "Diğerlerini Kapat",
+			"closeToTheLeft": "Soldakileri Kapat",
+			"closeToTheRight": "Sağdakileri Kapat",
+			"closeAll": "Hepsini Kapat"
+		}
 	},
 	"tag": {
 		"addNestedTag": "Etiket hiyerarşisi oluştur...",

--- a/packages/app/src/locales/uk/menu.json
+++ b/packages/app/src/locales/uk/menu.json
@@ -23,7 +23,14 @@
 		"copyMarkdownLink": "Копіювати посилання Markdown",
 		"deletePermanently": "Видалити назавжди",
 		"restoreFromBin": "Відновити з кошика",
-		"deleteToBin": "Перемістити в кошик"
+		"deleteToBin": "Перемістити в кошик",
+		"tab": {
+			"close": "Закрити",
+			"closeOthers": "Закрити інші",
+			"closeToTheLeft": "Закрити вкладки ліворуч",
+			"closeToTheRight": "Закрити вкладки праворуч",
+			"closeAll": "Закрити всі"
+		}
 	},
 	"tag": {
 		"addNestedTag": "Створити ієрархію тегів...",

--- a/packages/app/src/locales/vi/menu.json
+++ b/packages/app/src/locales/vi/menu.json
@@ -23,7 +23,14 @@
 		"copyMarkdownLink": "Sao chép liên kết Markdown",
 		"deletePermanently": "Xóa vĩnh viễn",
 		"restoreFromBin": "Khôi phục từ thùng rác",
-		"deleteToBin": "Chuyển vào thùng rác"
+		"deleteToBin": "Chuyển vào thùng rác",
+		"tab": {
+			"close": "Đóng",
+			"closeOthers": "Đóng các tab khác",
+			"closeToTheLeft": "Đóng các tab bên trái",
+			"closeToTheRight": "Đóng các tab bên phải",
+			"closeAll": "Đóng tất cả"
+		}
 	},
 	"tag": {
 		"addNestedTag": "Tạo phân cấp thẻ...",

--- a/packages/app/src/locales/zh-CN/menu.json
+++ b/packages/app/src/locales/zh-CN/menu.json
@@ -23,7 +23,14 @@
 		"copyMarkdownLink": "复制 Markdown 链接",
 		"deletePermanently": "永久删除",
 		"restoreFromBin": "从回收站恢复",
-		"deleteToBin": "移至回收站"
+		"deleteToBin": "移至回收站",
+		"tab": {
+			"close": "关闭",
+			"closeOthers": "关闭其他",
+			"closeToTheLeft": "关闭左侧标签",
+			"closeToTheRight": "关闭右侧标签",
+			"closeAll": "关闭全部"
+		}
 	},
 	"tag": {
 		"addNestedTag": "创建层级标签...",

--- a/packages/app/src/locales/zh-TW/menu.json
+++ b/packages/app/src/locales/zh-TW/menu.json
@@ -23,7 +23,14 @@
 		"copyMarkdownLink": "複製 Markdown 連結",
 		"deletePermanently": "永久刪除",
 		"restoreFromBin": "從回收桶還原",
-		"deleteToBin": "移至回收桶"
+		"deleteToBin": "移至回收桶",
+		"tab": {
+			"close": "關閉",
+			"closeOthers": "關閉其他",
+			"closeToTheLeft": "關閉左側分頁",
+			"closeToTheRight": "關閉右側分頁",
+			"closeAll": "全部關閉"
+		}
 	},
 	"tag": {
 		"addNestedTag": "新增標籤層級...",

--- a/packages/app/src/state/redux/vaults/__tests__/redux.vault.activeNote.test.ts
+++ b/packages/app/src/state/redux/vaults/__tests__/redux.vault.activeNote.test.ts
@@ -1,0 +1,120 @@
+import { createTestStore, mockNoteObject } from '@tests/utils/redux';
+
+import { selectActiveNoteId, workspacesApi } from '../vaults';
+
+describe('Active note consistency', () => {
+	const { store, workspaceScope, selectors } = createTestStore();
+
+	// Init state
+	beforeAll(() => {
+		store.dispatch(
+			workspacesApi.setOpenedNotes({
+				...workspaceScope,
+				notes: [mockNoteObject('1'), mockNoteObject('2'), mockNoteObject('3')],
+			}),
+		);
+	});
+
+	test('Any opened note can be set as an active note', () => {
+		store.dispatch(
+			workspacesApi.setActiveNote({
+				...workspaceScope,
+				noteId: '1',
+			}),
+		);
+		expect(selectActiveNoteId(selectors.workspace())).toStrictEqual('1');
+
+		store.dispatch(
+			workspacesApi.setActiveNote({
+				...workspaceScope,
+				noteId: '2',
+			}),
+		);
+		expect(selectActiveNoteId(selectors.workspace())).toStrictEqual('2');
+	});
+
+	test('Note id out of opened notes list must be ignored, active note must not be changed', () => {
+		store.dispatch(
+			workspacesApi.setActiveNote({
+				...workspaceScope,
+				noteId: '1',
+			}),
+		);
+		expect(selectActiveNoteId(selectors.workspace())).toStrictEqual('1');
+
+		// Invalid note cannot be selected
+		store.dispatch(
+			workspacesApi.setActiveNote({
+				...workspaceScope,
+				noteId: '999',
+			}),
+		);
+		expect(selectActiveNoteId(selectors.workspace())).toStrictEqual('1');
+	});
+});
+
+describe('Active note management', () => {
+	test('Active note must be changed when current note is closed', () => {
+		const { store, workspaceScope, selectors } = createTestStore();
+		store.dispatch(
+			workspacesApi.setOpenedNotes({
+				...workspaceScope,
+				notes: [
+					mockNoteObject('1'),
+					mockNoteObject('2'),
+					mockNoteObject('3'),
+					mockNoteObject('4'),
+					mockNoteObject('5'),
+				],
+			}),
+		);
+
+		store.dispatch(
+			workspacesApi.setActiveNote({
+				...workspaceScope,
+				noteId: '3',
+			}),
+		);
+		expect(selectActiveNoteId(selectors.workspace())).toStrictEqual('3');
+
+		store.dispatch(
+			workspacesApi.removeOpenedNote({
+				...workspaceScope,
+				noteId: '3',
+			}),
+		);
+		expect(selectActiveNoteId(selectors.workspace())).toStrictEqual('2');
+
+		store.dispatch(
+			workspacesApi.removeOpenedNote({
+				...workspaceScope,
+				noteId: '2',
+			}),
+		);
+		expect(selectActiveNoteId(selectors.workspace())).toStrictEqual('1');
+
+		store.dispatch(
+			workspacesApi.removeOpenedNote({
+				...workspaceScope,
+				noteId: '1',
+			}),
+		);
+		expect(selectActiveNoteId(selectors.workspace())).toStrictEqual('4');
+
+		store.dispatch(
+			workspacesApi.removeOpenedNote({
+				...workspaceScope,
+				noteId: '4',
+			}),
+		);
+		expect(selectActiveNoteId(selectors.workspace())).toStrictEqual('5');
+
+		store.dispatch(
+			workspacesApi.removeOpenedNote({
+				...workspaceScope,
+				noteId: '5',
+			}),
+		);
+		expect(selectActiveNoteId(selectors.workspace())).toStrictEqual(null);
+	});
+});

--- a/packages/app/src/state/redux/vaults/__tests__/redux.vault.activeNote.test.ts
+++ b/packages/app/src/state/redux/vaults/__tests__/redux.vault.activeNote.test.ts
@@ -1,6 +1,11 @@
 import { createTestStore, mockNoteObject } from '@tests/utils/redux';
 
-import { selectActiveNoteId, workspacesApi } from '../vaults';
+import {
+	selectActiveNoteId,
+	selectOpenedNotes,
+	selectRecentlyClosedNotes,
+	workspacesApi,
+} from '../vaults';
 
 describe('Active note consistency', () => {
 	const { store, workspaceScope, selectors } = createTestStore();
@@ -116,5 +121,196 @@ describe('Active note management', () => {
 			}),
 		);
 		expect(selectActiveNoteId(selectors.workspace())).toStrictEqual(null);
+	});
+});
+
+describe('Close note tabs via queries', () => {
+	test('Close all notes after N', () => {
+		const { store, workspaceScope, selectors } = createTestStore();
+		store.dispatch(
+			workspacesApi.setOpenedNotes({
+				...workspaceScope,
+				notes: [
+					mockNoteObject('1'),
+					mockNoteObject('2'),
+					mockNoteObject('3'),
+					mockNoteObject('4'),
+					mockNoteObject('5'),
+				],
+			}),
+		);
+
+		store.dispatch(
+			workspacesApi.setActiveNote({
+				...workspaceScope,
+				noteId: '3',
+			}),
+		);
+		store.dispatch(
+			workspacesApi.closeNotes({
+				...workspaceScope,
+				query: {
+					afterNoteId: '3',
+				},
+			}),
+		);
+		expect(selectActiveNoteId(selectors.workspace())).toStrictEqual('3');
+		expect(selectOpenedNotes(selectors.workspace())).toStrictEqual([
+			mockNoteObject('1'),
+			mockNoteObject('2'),
+			mockNoteObject('3'),
+		]);
+	});
+
+	test('Close all notes before N', () => {
+		const { store, workspaceScope, selectors } = createTestStore();
+		store.dispatch(
+			workspacesApi.setOpenedNotes({
+				...workspaceScope,
+				notes: [
+					mockNoteObject('1'),
+					mockNoteObject('2'),
+					mockNoteObject('3'),
+					mockNoteObject('4'),
+					mockNoteObject('5'),
+				],
+			}),
+		);
+
+		store.dispatch(
+			workspacesApi.setActiveNote({
+				...workspaceScope,
+				noteId: '3',
+			}),
+		);
+		store.dispatch(
+			workspacesApi.closeNotes({
+				...workspaceScope,
+				query: {
+					beforeNoteId: '3',
+				},
+			}),
+		);
+		expect(selectActiveNoteId(selectors.workspace())).toStrictEqual('3');
+		expect(selectOpenedNotes(selectors.workspace())).toStrictEqual([
+			mockNoteObject('3'),
+			mockNoteObject('4'),
+			mockNoteObject('5'),
+		]);
+	});
+
+	test('Close all notes before N and after N', () => {
+		const { store, workspaceScope, selectors } = createTestStore();
+		store.dispatch(
+			workspacesApi.setOpenedNotes({
+				...workspaceScope,
+				notes: [
+					mockNoteObject('1'),
+					mockNoteObject('2'),
+					mockNoteObject('3'),
+					mockNoteObject('4'),
+					mockNoteObject('5'),
+				],
+			}),
+		);
+
+		store.dispatch(
+			workspacesApi.setActiveNote({
+				...workspaceScope,
+				noteId: '3',
+			}),
+		);
+		store.dispatch(
+			workspacesApi.closeNotes({
+				...workspaceScope,
+				query: {
+					beforeNoteId: '3',
+					afterNoteId: '3',
+				},
+			}),
+		);
+		expect(selectActiveNoteId(selectors.workspace())).toStrictEqual('3');
+		expect(selectOpenedNotes(selectors.workspace())).toStrictEqual([
+			mockNoteObject('3'),
+		]);
+	});
+
+	test('Close all notes before N and after N but exclude specific ids', () => {
+		const { store, workspaceScope, selectors } = createTestStore();
+		store.dispatch(
+			workspacesApi.setOpenedNotes({
+				...workspaceScope,
+				notes: [
+					mockNoteObject('1'),
+					mockNoteObject('2'),
+					mockNoteObject('3'),
+					mockNoteObject('4'),
+					mockNoteObject('5'),
+				],
+			}),
+		);
+
+		store.dispatch(
+			workspacesApi.setActiveNote({
+				...workspaceScope,
+				noteId: '3',
+			}),
+		);
+		store.dispatch(
+			workspacesApi.closeNotes({
+				...workspaceScope,
+				query: {
+					beforeNoteId: '3',
+					afterNoteId: '3',
+					exclude: ['4'],
+				},
+			}),
+		);
+		expect(selectActiveNoteId(selectors.workspace())).toStrictEqual('3');
+		expect(selectOpenedNotes(selectors.workspace())).toStrictEqual([
+			mockNoteObject('3'),
+			mockNoteObject('4'),
+		]);
+	});
+
+	test('Close specific note ids', () => {
+		const { store, workspaceScope, selectors } = createTestStore();
+		store.dispatch(
+			workspacesApi.setOpenedNotes({
+				...workspaceScope,
+				notes: [
+					mockNoteObject('1'),
+					mockNoteObject('2'),
+					mockNoteObject('3'),
+					mockNoteObject('4'),
+					mockNoteObject('5'),
+				],
+			}),
+		);
+
+		store.dispatch(
+			workspacesApi.setActiveNote({
+				...workspaceScope,
+				noteId: '3',
+			}),
+		);
+		store.dispatch(
+			workspacesApi.closeNotes({
+				...workspaceScope,
+				query: {
+					noteIds: ['2', '3', '4'],
+				},
+			}),
+		);
+		expect(selectActiveNoteId(selectors.workspace())).toStrictEqual('1');
+		expect(selectOpenedNotes(selectors.workspace())).toStrictEqual([
+			mockNoteObject('1'),
+			mockNoteObject('5'),
+		]);
+		expect(selectRecentlyClosedNotes(selectors.workspace())).toStrictEqual([
+			'2',
+			'3',
+			'4',
+		]);
 	});
 });

--- a/packages/app/src/state/redux/vaults/__tests__/redux.vault.activeNote.test.ts
+++ b/packages/app/src/state/redux/vaults/__tests__/redux.vault.activeNote.test.ts
@@ -125,8 +125,8 @@ describe('Active note management', () => {
 });
 
 describe('Close note tabs via queries', () => {
-	test('Close all notes after N', () => {
-		const { store, workspaceScope, selectors } = createTestStore();
+	const { store, workspaceScope, selectors } = createTestStore();
+	beforeEach(() => {
 		store.dispatch(
 			workspacesApi.setOpenedNotes({
 				...workspaceScope,
@@ -146,6 +146,9 @@ describe('Close note tabs via queries', () => {
 				noteId: '3',
 			}),
 		);
+	});
+
+	test('Close all notes after N', () => {
 		store.dispatch(
 			workspacesApi.closeNotes({
 				...workspaceScope,
@@ -163,26 +166,6 @@ describe('Close note tabs via queries', () => {
 	});
 
 	test('Close all notes before N', () => {
-		const { store, workspaceScope, selectors } = createTestStore();
-		store.dispatch(
-			workspacesApi.setOpenedNotes({
-				...workspaceScope,
-				notes: [
-					mockNoteObject('1'),
-					mockNoteObject('2'),
-					mockNoteObject('3'),
-					mockNoteObject('4'),
-					mockNoteObject('5'),
-				],
-			}),
-		);
-
-		store.dispatch(
-			workspacesApi.setActiveNote({
-				...workspaceScope,
-				noteId: '3',
-			}),
-		);
 		store.dispatch(
 			workspacesApi.closeNotes({
 				...workspaceScope,
@@ -200,26 +183,6 @@ describe('Close note tabs via queries', () => {
 	});
 
 	test('Close all notes before N and after N', () => {
-		const { store, workspaceScope, selectors } = createTestStore();
-		store.dispatch(
-			workspacesApi.setOpenedNotes({
-				...workspaceScope,
-				notes: [
-					mockNoteObject('1'),
-					mockNoteObject('2'),
-					mockNoteObject('3'),
-					mockNoteObject('4'),
-					mockNoteObject('5'),
-				],
-			}),
-		);
-
-		store.dispatch(
-			workspacesApi.setActiveNote({
-				...workspaceScope,
-				noteId: '3',
-			}),
-		);
 		store.dispatch(
 			workspacesApi.closeNotes({
 				...workspaceScope,
@@ -236,20 +199,6 @@ describe('Close note tabs via queries', () => {
 	});
 
 	test('Close all notes before N and after N but exclude specific ids', () => {
-		const { store, workspaceScope, selectors } = createTestStore();
-		store.dispatch(
-			workspacesApi.setOpenedNotes({
-				...workspaceScope,
-				notes: [
-					mockNoteObject('1'),
-					mockNoteObject('2'),
-					mockNoteObject('3'),
-					mockNoteObject('4'),
-					mockNoteObject('5'),
-				],
-			}),
-		);
-
 		store.dispatch(
 			workspacesApi.setActiveNote({
 				...workspaceScope,
@@ -274,26 +223,6 @@ describe('Close note tabs via queries', () => {
 	});
 
 	test('Close specific note ids', () => {
-		const { store, workspaceScope, selectors } = createTestStore();
-		store.dispatch(
-			workspacesApi.setOpenedNotes({
-				...workspaceScope,
-				notes: [
-					mockNoteObject('1'),
-					mockNoteObject('2'),
-					mockNoteObject('3'),
-					mockNoteObject('4'),
-					mockNoteObject('5'),
-				],
-			}),
-		);
-
-		store.dispatch(
-			workspacesApi.setActiveNote({
-				...workspaceScope,
-				noteId: '3',
-			}),
-		);
 		store.dispatch(
 			workspacesApi.closeNotes({
 				...workspaceScope,
@@ -307,10 +236,52 @@ describe('Close note tabs via queries', () => {
 			mockNoteObject('1'),
 			mockNoteObject('5'),
 		]);
-		expect(selectRecentlyClosedNotes(selectors.workspace())).toStrictEqual([
+		expect(selectRecentlyClosedNotes(selectors.workspace()).slice(-3)).toStrictEqual([
 			'2',
 			'3',
 			'4',
+		]);
+	});
+
+	test('Close all notes', () => {
+		store.dispatch(
+			workspacesApi.closeNotes({
+				...workspaceScope,
+				query: {
+					all: true,
+				},
+			}),
+		);
+		expect(selectActiveNoteId(selectors.workspace())).toStrictEqual(null);
+		expect(selectOpenedNotes(selectors.workspace())).toStrictEqual([]);
+		expect(selectRecentlyClosedNotes(selectors.workspace()).slice(-5)).toStrictEqual([
+			'1',
+			'2',
+			'3',
+			'4',
+			'5',
+		]);
+	});
+
+	test('Close all notes except N', () => {
+		store.dispatch(
+			workspacesApi.closeNotes({
+				...workspaceScope,
+				query: {
+					all: true,
+					exclude: ['3', '4'],
+				},
+			}),
+		);
+		expect(selectActiveNoteId(selectors.workspace())).toStrictEqual('3');
+		expect(selectOpenedNotes(selectors.workspace())).toStrictEqual([
+			mockNoteObject('3'),
+			mockNoteObject('4'),
+		]);
+		expect(selectRecentlyClosedNotes(selectors.workspace()).slice(-3)).toStrictEqual([
+			'1',
+			'2',
+			'5',
 		]);
 	});
 });

--- a/packages/app/src/state/redux/vaults/redux-workspace-utils.test.ts
+++ b/packages/app/src/state/redux/vaults/redux-workspace-utils.test.ts
@@ -1,0 +1,36 @@
+import { INote } from '@core/features/notes';
+
+import { findNearNote } from './utils';
+
+const mockNoteObject = (id: string) => ({ id }) as unknown as INote;
+const mockNoteIds = (ids: string[]) => ids.map((id) => mockNoteObject(id));
+
+describe('findNearNote util', () => {
+	test('Must return previous note by default', () => {
+		expect(findNearNote(mockNoteIds(['1', '2', '3', '4', '5']), '3')).toEqual(
+			mockNoteObject('2'),
+		);
+	});
+
+	test('Must return previous note for the last id', () => {
+		expect(findNearNote(mockNoteIds(['1', '2', '3', '4', '5']), '5')).toEqual(
+			mockNoteObject('4'),
+		);
+	});
+
+	test('Must return next note for the first id', () => {
+		expect(findNearNote(mockNoteIds(['1', '2', '3', '4', '5']), '1')).toEqual(
+			mockNoteObject('2'),
+		);
+	});
+
+	test('Must return last note for not found id', () => {
+		expect(findNearNote(mockNoteIds(['1', '2', '3', '4', '5']), '111')).toEqual(
+			mockNoteObject('5'),
+		);
+	});
+
+	test('Must return null if nothing found', () => {
+		expect(findNearNote(mockNoteIds(['1']), '1')).toBeNull();
+	});
+});

--- a/packages/app/src/state/redux/vaults/vaults.ts
+++ b/packages/app/src/state/redux/vaults/vaults.ts
@@ -403,6 +403,7 @@ export const vaultsSlice = createSlice({
 			}: PayloadAction<
 				WorkspaceScoped<{
 					query: {
+						all?: true;
 						noteIds?: NoteId[];
 						exclude?: NoteId[];
 						afterNoteId?: NoteId;
@@ -426,7 +427,8 @@ export const vaultsSlice = createSlice({
 
 			// Update opened notes
 			const filteredNotes = openedNotes.filter(({ id }) => {
-				const defaultResult = !targets.has(id) || excludes.has(id);
+				const defaultResult =
+					excludes.has(id) || (!targets.has(id) && !query.all);
 
 				if (query.afterNoteId) {
 					if (edgesReached.after) {

--- a/packages/app/src/state/redux/vaults/vaults.ts
+++ b/packages/app/src/state/redux/vaults/vaults.ts
@@ -396,6 +396,89 @@ export const vaultsSlice = createSlice({
 			workspace.recentlyClosedNotes.push(noteId);
 		},
 
+		closeNotes: (
+			state,
+			{
+				payload: { vaultId, workspaceId, query },
+			}: PayloadAction<
+				WorkspaceScoped<{
+					query: {
+						noteIds?: NoteId[];
+						exclude?: NoteId[];
+						afterNoteId?: NoteId;
+						beforeNoteId?: NoteId;
+					};
+				}>
+			>,
+		) => {
+			const workspace = selectWorkspaceObject(state, { vaultId, workspaceId });
+			if (!workspace) return;
+
+			const targets = new Set(query.noteIds ?? []);
+			const excludes = new Set(query.exclude ?? []);
+
+			const { activeNote, openedNotes } = workspace;
+
+			const edgesReached = {
+				after: false,
+				before: false,
+			};
+
+			// Update opened notes
+			const filteredNotes = openedNotes.filter(({ id }) => {
+				const defaultResult = !targets.has(id) || excludes.has(id);
+
+				if (query.afterNoteId) {
+					if (edgesReached.after) {
+						return excludes.has(id);
+					} else if (id === query.afterNoteId) edgesReached.after = true;
+				}
+
+				if (query.beforeNoteId && !edgesReached.before) {
+					if (id === query.beforeNoteId) edgesReached.before = true;
+					else return excludes.has(id);
+				}
+
+				return defaultResult;
+			});
+			const filteredNoteIds = new Set(filteredNotes.map((note) => note.id));
+
+			workspace.openedNotes = filteredNotes;
+
+			// Update active note
+			const isActiveNoteMustBeUpdated =
+				activeNote !== null && filteredNotes.every(({ id }) => id !== activeNote);
+			if (isActiveNoteMustBeUpdated) {
+				if (filteredNotes.length === 0) workspace.activeNote = null;
+				else if (filteredNotes.length === 1)
+					workspace.activeNote = filteredNotes[0].id;
+				else {
+					const activeNoteIndex = openedNotes.findIndex(
+						(note) => note.id === activeNote,
+					);
+
+					// Candidates list sorted by priority
+					const candidates = [
+						...openedNotes.slice(0, activeNoteIndex).reverse(),
+						...openedNotes.slice(activeNoteIndex + 1),
+					];
+
+					const noteId = candidates.find((candidate) =>
+						filteredNoteIds.has(candidate.id),
+					);
+
+					workspace.activeNote = noteId?.id ?? null;
+				}
+			}
+
+			// Update recently closed
+			workspace.recentlyClosedNotes.push(
+				...openedNotes
+					.filter((note) => !filteredNoteIds.has(note.id))
+					.map((note) => note.id),
+			);
+		},
+
 		updateOpenedNote: (
 			state,
 			{


### PR DESCRIPTION
Closes #300

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Expanded note tab context menu with new close options: close current note, close all, close other notes, close to the left/right.

* **Tests**
  * Added test utilities for Redux-backed store setup and note mocking. Added tests covering active-note behavior and many close-notes scenarios (by range, exclusions, explicit lists, and all).

* **Localization**
  * Added tab-related menu translations across many locales.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/DeepinkApp/deepink/pull/302?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->