### PR TITLE
fix: Note content does not update after applying history

### DIFF
--- a/packages/app/src/core/features/notes/controller/NotesController.test.ts
+++ b/packages/app/src/core/features/notes/controller/NotesController.test.ts
@@ -101,7 +101,7 @@ describe('CRUD operations', () => {
 		await expect(registry.delete([])).resolves.not.toThrow();
 	});
 
-	test('update method updates a note by note ID, not by ID in the payload', async () => {
+	test('update method ignores unexpected payload fields and correctly updates the note', async () => {
 		const dbFile = createFileControllerMock();
 		const managedDB = await openSQLite(dbFile);
 		onTestFinished(() => managedDB.close());
@@ -121,17 +121,15 @@ describe('CRUD operations', () => {
 		await registry.update(noteId, updatedContentWithOwnId);
 
 		// The payload ID should not affect the note update
-		await expect(registry.getById([noteId])).resolves.toEqual(
-			expect.arrayContaining([
-				expect.objectContaining({
-					id: noteId,
-					content: {
-						text: 'Updated text',
-						title: 'Updated title',
-					},
-				}),
-			]),
-		);
+		await expect(registry.getById([noteId])).resolves.toStrictEqual([
+			expect.objectContaining({
+				id: noteId,
+				content: {
+					text: 'Updated text',
+					title: 'Updated title',
+				},
+			}),
+		]);
 	});
 });
 

--- a/packages/app/src/core/features/notes/controller/NotesController.test.ts
+++ b/packages/app/src/core/features/notes/controller/NotesController.test.ts
@@ -120,10 +120,11 @@ describe('CRUD operations', () => {
 
 		await registry.update(noteId, updatedContentWithOwnId);
 
-		// The note should contain the updated content
+		// The payload ID should not affect the note update
 		await expect(registry.getById([noteId])).resolves.toEqual(
 			expect.arrayContaining([
 				expect.objectContaining({
+					id: noteId,
 					content: {
 						text: 'Updated text',
 						title: 'Updated title',

--- a/packages/app/src/core/features/notes/controller/NotesController.test.ts
+++ b/packages/app/src/core/features/notes/controller/NotesController.test.ts
@@ -100,6 +100,38 @@ describe('CRUD operations', () => {
 
 		await expect(registry.delete([])).resolves.not.toThrow();
 	});
+
+	test('update method updates a note by note ID, not by ID in the payload', async () => {
+		const dbFile = createFileControllerMock();
+		const managedDB = await openSQLite(dbFile);
+		onTestFinished(() => managedDB.close());
+
+		const workspaceId = await createWorkspaceId(managedDB.get());
+		const registry = new NotesController(managedDB.get(), workspaceId);
+
+		const noteId = await registry.add({ title: 'Title', text: 'Text' });
+
+		// The object contains its own ID field, but it should not overwrite the note ID
+		const updatedContentWithOwnId = {
+			id: crypto.randomUUID(),
+			text: 'Updated text',
+			title: 'Updated title',
+		};
+
+		await registry.update(noteId, updatedContentWithOwnId);
+
+		// The note should contain the updated content
+		await expect(registry.getById([noteId])).resolves.toEqual(
+			expect.arrayContaining([
+				expect.objectContaining({
+					content: {
+						text: 'Updated text',
+						title: 'Updated title',
+					},
+				}),
+			]),
+		);
+	});
 });
 
 test('Many instances reads the data consistently', async () => {

--- a/packages/app/src/core/features/notes/controller/NotesController.ts
+++ b/packages/app/src/core/features/notes/controller/NotesController.ts
@@ -347,7 +347,7 @@ export class NotesController implements INotesController {
 	}
 
 	public async update(id: string, updatedNote: INoteContent) {
-		await this.updateBatch([{ id, ...updatedNote }]);
+		await this.updateBatch([{ ...updatedNote, id }]);
 	}
 
 	public async updateBatch(notes: NoteContentUpdateInfo[]) {

--- a/packages/app/src/features/NoteEditor/index.tsx
+++ b/packages/app/src/features/NoteEditor/index.tsx
@@ -530,6 +530,8 @@ export const Note: FC<NoteEditorProps> = memo(
 															await noteHistory.snapshot(
 																note.id,
 															);
+
+															// Version contains extra fields, but require only text and title
 															await notesRegistry.update(
 																note.id,
 																{

--- a/packages/app/src/features/NoteEditor/index.tsx
+++ b/packages/app/src/features/NoteEditor/index.tsx
@@ -532,7 +532,10 @@ export const Note: FC<NoteEditorProps> = memo(
 															);
 															await notesRegistry.update(
 																note.id,
-																version,
+																{
+																	title: version.title,
+																	text: version.text,
+																},
 															);
 															await noteHistory.snapshot(
 																note.id,


### PR DESCRIPTION
Closes #301 

When applying history, we call the note controller’s `update` method, which expects a note ID and a content object of type `INoteContent` (title, text fields). But we pass an object of type `NoteVersion`, which has additional fields, including its own ID.

Inside the `update` method, the content object is spread together with the note’s ID. Since the version object also contains an ID, it overwrites the note’s ID during the spread, causing the bug.

TS does not throw an error when we call the update method, because TS uses structural typing. I could not find any ESLint rules or tsconfig settings to prevent this.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Applying a note version now updates only the title and text and records history snapshots before and after the change for reliable versioning.
  * Note updates now always respect the target note ID (payload cannot overwrite it); added a test to verify this behavior.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/DeepinkApp/deepink/pull/305?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->