### PR TITLE
perf: note versions renders 700ms

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9955,12 +9955,12 @@
 			}
 		},
 		"node_modules/@tanstack/react-virtual": {
-			"version": "3.13.18",
-			"resolved": "https://registry.npmjs.org/@tanstack/react-virtual/-/react-virtual-3.13.18.tgz",
-			"integrity": "sha512-dZkhyfahpvlaV0rIKnvQiVoWPyURppl6w4m9IwMDpuIjcJ1sD9YGWrt0wISvgU7ewACXx2Ct46WPgI6qAD4v6A==",
+			"version": "3.14.2",
+			"resolved": "https://registry.npmjs.org/@tanstack/react-virtual/-/react-virtual-3.14.2.tgz",
+			"integrity": "sha512-IpWnmCLvuymRfeeLNVXIzNEYBFLpd3drVIS91sqV78VTZFyldlChkOocZRCPp1B+Wnk09bcLNme8WaMU/9/9bQ==",
 			"license": "MIT",
 			"dependencies": {
-				"@tanstack/virtual-core": "3.13.18"
+				"@tanstack/virtual-core": "3.17.0"
 			},
 			"funding": {
 				"type": "github",
@@ -9972,9 +9972,9 @@
 			}
 		},
 		"node_modules/@tanstack/virtual-core": {
-			"version": "3.13.18",
-			"resolved": "https://registry.npmjs.org/@tanstack/virtual-core/-/virtual-core-3.13.18.tgz",
-			"integrity": "sha512-Mx86Hqu1k39icq2Zusq+Ey2J6dDWTjDvEv43PJtRCoEYTLyfaPnxIQ6iy7YAOK0NV/qOEmZQ/uCufrppZxTgcg==",
+			"version": "3.17.0",
+			"resolved": "https://registry.npmjs.org/@tanstack/virtual-core/-/virtual-core-3.17.0.tgz",
+			"integrity": "sha512-gOxY/hFkPh/XQYhnThBHzkbkX3Ed+z/iushyz+R+JAr213aXxUDgQoTgTdrDpBSRsjFM73P/KfUyWmaF9WHMkQ==",
 			"license": "MIT",
 			"funding": {
 				"type": "github",
@@ -35214,7 +35214,7 @@
 				"@lexical/react": "^0.39.0",
 				"@msgpack/msgpack": "^3.1.3",
 				"@reduxjs/toolkit": "^2.11.2",
-				"@tanstack/react-virtual": "^3.13.18",
+				"@tanstack/react-virtual": "^3.14.2",
 				"arrival-time": "^1.0.6",
 				"async-mutex": "^0.5.0",
 				"bytes": "^3.1.2",

--- a/packages/app/package.json
+++ b/packages/app/package.json
@@ -111,7 +111,7 @@
 		"@lexical/react": "^0.39.0",
 		"@msgpack/msgpack": "^3.1.3",
 		"@reduxjs/toolkit": "^2.11.2",
-		"@tanstack/react-virtual": "^3.13.18",
+		"@tanstack/react-virtual": "^3.14.2",
 		"arrival-time": "^1.0.6",
 		"async-mutex": "^0.5.0",
 		"bytes": "^3.1.2",

--- a/packages/app/src/features/MainScreen/NotesListPanel/NotesList.tsx
+++ b/packages/app/src/features/MainScreen/NotesListPanel/NotesList.tsx
@@ -54,7 +54,12 @@ export const NotesList: FC<NotesListProps> = () => {
 		enabled: isActiveWorkspace,
 		count: noteIds.length,
 		getScrollElement: () => parentRef.current,
-		estimateSize: useEstimateVirtualItemSize(parentRef, { defaultSize: 180 }),
+		estimateSize: useEstimateVirtualItemSize(parentRef, {
+			defaultSize: 180,
+			getItemKey(index) {
+				return noteIds[index];
+			},
+		}),
 		overscan: 5,
 		useFlushSync: false,
 	});

--- a/packages/app/src/features/MainScreen/NotesListPanel/NotesList.tsx
+++ b/packages/app/src/features/MainScreen/NotesListPanel/NotesList.tsx
@@ -11,6 +11,7 @@ import { useNoteContextMenu } from '@features/NotesContainer/NoteContextMenu/use
 import { useTelemetryTracker } from '@features/telemetry';
 import { useCreateNote } from '@hooks/notes/useCreateNote';
 import { useNoteActions } from '@hooks/notes/useNoteActions';
+import { useEstimateVirtualItemSize } from '@hooks/useEstimateVirtualItemSize';
 import { useIsActiveWorkspace } from '@hooks/useIsActiveWorkspace';
 import { useWorkspaceSelector } from '@state/redux/vaults/hooks';
 import {
@@ -53,7 +54,7 @@ export const NotesList: FC<NotesListProps> = () => {
 		enabled: isActiveWorkspace,
 		count: noteIds.length,
 		getScrollElement: () => parentRef.current,
-		estimateSize: () => 180,
+		estimateSize: useEstimateVirtualItemSize(parentRef, { defaultSize: 180 }),
 		overscan: 5,
 		useFlushSync: false,
 	});

--- a/packages/app/src/features/MainScreen/TagsPanel/VirtualTagsList.tsx
+++ b/packages/app/src/features/MainScreen/TagsPanel/VirtualTagsList.tsx
@@ -1,6 +1,7 @@
 import React, { forwardRef, useCallback, useImperativeHandle, useRef } from 'react';
 import { Box, useSlotRecipe } from '@chakra-ui/react';
 import { ItemInstance, TreeInstance } from '@headless-tree/core';
+import { useEstimateVirtualItemSize } from '@hooks/useEstimateVirtualItemSize';
 import { TagNode } from '@state/redux/vaults/vaults';
 import { useVirtualizer, Virtualizer } from '@tanstack/react-virtual';
 
@@ -22,7 +23,7 @@ export const VirtualTagsList = forwardRef<
 	const virtualizer = useVirtualizer({
 		count: tree.getItems().length,
 		getScrollElement: () => parentRef.current,
-		estimateSize: () => 38,
+		estimateSize: useEstimateVirtualItemSize(parentRef, { defaultSize: 38 }),
 		useFlushSync: false,
 		overscan: 10,
 	});

--- a/packages/app/src/features/NoteEditor/NoteVersions.tsx
+++ b/packages/app/src/features/NoteEditor/NoteVersions.tsx
@@ -1,16 +1,27 @@
-import React, { useCallback, useEffect, useState } from 'react';
+import React, { forwardRef, memo, useCallback, useEffect, useRef, useState } from 'react';
 import { Trans, useTranslation } from 'react-i18next';
 import { FaCheck, FaEraser, FaFloppyDisk, FaGlasses, FaTrashCan } from 'react-icons/fa6';
 import { LOCALE_NAMESPACE } from 'src/i18n';
 import { WorkspaceEvents } from '@api/events/workspace';
-import { Box, Button, HStack, Switch, Text, VStack } from '@chakra-ui/react';
+import {
+	Box,
+	Button,
+	HStack,
+	Stack,
+	StackProps,
+	Switch,
+	Text,
+	VStack,
+} from '@chakra-ui/react';
 import { BoxWithCenteredContent } from '@components/BoxWithCenteredContent';
 import { TextWithIcon } from '@components/TextWithIcon';
 import { NoteVersion } from '@core/features/notes/history/NoteVersions';
 import { TELEMETRY_EVENT_NAME } from '@core/features/telemetry';
 import { useEventBus, useNotesHistory } from '@features/App/Workspace/WorkspaceProvider';
+import { useMemoizedCallback } from '@features/MainScreen/TagsPanel/useMemoizedCallback';
 import { useTelemetryTracker } from '@features/telemetry';
 import { useConfirmDialog } from '@hooks/useConfirmDialog';
+import { useVirtualizer } from '@tanstack/react-virtual';
 
 const ONE_DAY_IN_MS = 1000 * 60 * 60 * 24;
 const timestampToDays = (ms: number) => Math.floor(ms / ONE_DAY_IN_MS);
@@ -18,6 +29,73 @@ const getTimestampAgeInDays = (ms: number) => timestampToDays(Date.now() - ms);
 
 export const formatNoteVersionPreview = (version: NoteVersion) =>
 	`${new Date(version.createdAt).toLocaleString()} (${version.text.length} chars)`;
+
+export const NoteVersionItem = memo(
+	forwardRef<
+		HTMLDivElement,
+		StackProps & {
+			version: NoteVersion;
+			isReadOnly?: boolean;
+			onDelete: () => void;
+			onApply: () => void;
+			onPreview: () => void;
+		}
+	>(({ version, isReadOnly, onPreview, onApply, onDelete, ...props }, ref) => {
+		const { t } = useTranslation(LOCALE_NAMESPACE.features);
+
+		return (
+			<HStack
+				ref={ref}
+				w="100%"
+				align="start"
+				padding="0.3rem"
+				alignItems="center"
+				_hover={{ backgroundColor: 'dim.50' }}
+				{...props}
+			>
+				<HStack>
+					<Text>{new Date(version.createdAt).toLocaleString()}</Text>
+					<Text variant="secondary">
+						{t('note.version.chars', {
+							count: version.text.length,
+						})}
+					</Text>
+				</HStack>
+				<HStack marginLeft="auto">
+					<Button
+						disabled={Boolean(isReadOnly)}
+						size="xs"
+						title={
+							isReadOnly
+								? t('note.version.apply.readonlyTitle')
+								: t('note.version.apply.title')
+						}
+						onClick={onApply}
+					>
+						<FaCheck />
+					</Button>
+
+					<Button
+						size="xs"
+						title={t('note.version.open.title')}
+						onClick={onPreview}
+					>
+						<FaGlasses />
+					</Button>
+					<Button
+						size="xs"
+						title={t('note.version.delete.title')}
+						onClick={onDelete}
+					>
+						<FaTrashCan />
+					</Button>
+				</HStack>
+			</HStack>
+		);
+	}),
+);
+
+NoteVersionItem.displayName = 'NoteVersionItem';
 
 // TODO: implement lazy loading
 export const NoteVersions = ({
@@ -65,6 +143,154 @@ export const NoteVersions = ({
 	}, [eventBus, updateVersionsList]);
 
 	const confirm = useConfirmDialog();
+	const listRootRef = useRef<HTMLDivElement>(null);
+
+	const onApply = useMemoizedCallback(
+		useCallback(
+			(version: NoteVersion) => {
+				const applyVersion = () => {
+					onVersionApply(version);
+					telemetry.track(TELEMETRY_EVENT_NAME.NOTE_VERSION_APPLIED, {
+						versionAgeInDays: getTimestampAgeInDays(version.createdAt),
+					});
+				};
+
+				confirm(({ onClose }) => ({
+					title: t('note.versions.confirmApply.title'),
+					content: (
+						<VStack gap="1rem" align="start">
+							<Text>
+								<Trans
+									i18nKey="note.versions.confirmApply.description"
+									ns={LOCALE_NAMESPACE.features}
+									values={{
+										version: formatNoteVersionPreview(version),
+									}}
+									components={{
+										secondary: <Text as="span" variant="secondary" />,
+									}}
+								/>
+							</Text>
+							<Text>{t('note.versions.confirmApply.warning')}</Text>
+						</VStack>
+					),
+					action: (
+						<>
+							<Button
+								variant="accent"
+								onClick={() => {
+									applyVersion();
+									onClose();
+								}}
+							>
+								{t('note.versions.confirmApply.apply')}
+							</Button>
+							<Button
+								variant="accent"
+								onClick={() => {
+									onShowVersion(version);
+									onClose();
+								}}
+							>
+								{t('note.versions.confirmApply.preview')}
+							</Button>
+							<Button onClick={onClose}>
+								{t('common:actions.cancel')}
+							</Button>
+						</>
+					),
+				}));
+			},
+			[confirm, onShowVersion, onVersionApply, t, telemetry],
+		),
+	);
+
+	const onShow = useMemoizedCallback(
+		useCallback(
+			(version: NoteVersion) => {
+				console.log('onShow click');
+				onShowVersion(version);
+
+				telemetry.track(TELEMETRY_EVENT_NAME.NOTE_VERSION_VIEWED, {
+					versionAgeInDays: getTimestampAgeInDays(version.createdAt),
+				});
+			},
+			[onShowVersion, telemetry],
+		),
+	);
+
+	const onDelete = useMemoizedCallback(
+		useCallback(
+			(version: NoteVersion) => {
+				const deleteVersion = async () => {
+					await noteHistory.delete([version.id]);
+					eventBus.emit(WorkspaceEvents.NOTE_HISTORY_UPDATED, noteId);
+
+					telemetry.track(TELEMETRY_EVENT_NAME.NOTE_VERSION_DELETED, {
+						versionAgeInDays: getTimestampAgeInDays(version.createdAt),
+					});
+				};
+
+				confirm(({ onClose }) => ({
+					title: t('note.versions.confirmDelete.title'),
+					content: (
+						<VStack gap="1rem" align="start">
+							<Text>
+								<Trans
+									i18nKey="note.versions.confirmDelete.description"
+									ns={LOCALE_NAMESPACE.features}
+									values={{
+										version: formatNoteVersionPreview(version),
+									}}
+									components={{
+										secondary: <Text as="span" variant="secondary" />,
+									}}
+								/>
+							</Text>
+							<Text>{t('note.versions.confirmDelete.warning')}</Text>
+						</VStack>
+					),
+					action: (
+						<>
+							<Button
+								variant="accent"
+								onClick={() => {
+									deleteVersion();
+									onClose();
+								}}
+							>
+								{t('note.versions.confirmDelete.delete')}
+							</Button>
+							<Button
+								variant="accent"
+								onClick={() => {
+									onShowVersion(version);
+									onClose();
+								}}
+							>
+								{t('note.versions.confirmDelete.preview')}
+							</Button>
+							<Button onClick={onClose}>
+								{t('common:actions.cancel')}
+							</Button>
+						</>
+					),
+				}));
+			},
+			[confirm, eventBus, noteHistory, noteId, onShowVersion, t, telemetry],
+		),
+	);
+
+	// FIXME: https://github.com/TanStack/virtual/issues/1119
+	// eslint-disable-next-line react-hooks/incompatible-library
+	const virtualizer = useVirtualizer({
+		count: versions?.length ?? 0,
+		getScrollElement: () => listRootRef.current,
+		estimateSize: () => 20,
+		overscan: 6,
+		useFlushSync: false,
+		useCachedMeasurements: true,
+	});
 
 	return (
 		<VStack w="100%" maxH="100%">
@@ -147,7 +373,14 @@ export const NoteVersions = ({
 					</label>
 				</HStack>
 			</HStack>
-			<Box w="100%" overflow="auto" display="flex" flex={1} flexFlow="column">
+			<Box
+				ref={listRootRef}
+				width="100%"
+				overflow="auto"
+				display="flex"
+				flex={1}
+				flexFlow="column"
+			>
 				{versions && versions.length === 0 && (
 					<BoxWithCenteredContent>
 						<Text fontSize="1.3rem">{t('note.versions.empty')}</Text>
@@ -159,245 +392,32 @@ export const NoteVersions = ({
 					</BoxWithCenteredContent>
 				)}
 				{versions !== null && versions.length > 0 && (
-					<VStack w="100%" gap={0}>
-						{versions.map((version) => (
-							<HStack
-								key={version.id}
-								w="100%"
-								align="start"
-								padding="0.3rem"
-								alignItems="center"
-								_hover={{ backgroundColor: 'dim.50' }}
-							>
-								<HStack>
-									<Text>
-										{new Date(version.createdAt).toLocaleString()}
-									</Text>
-									<Text variant="secondary">
-										{t('note.version.chars', {
-											count: version.text.length,
-										})}
-									</Text>
-								</HStack>
-								<HStack marginLeft="auto">
-									<Button
-										disabled={Boolean(isReadOnly)}
-										size="xs"
-										title={
-											isReadOnly
-												? t('note.version.apply.readonlyTitle')
-												: t('note.version.apply.title')
-										}
-										onClick={(evt) => {
-											const applyVersion = () => {
-												onVersionApply(version);
-												telemetry.track(
-													TELEMETRY_EVENT_NAME.NOTE_VERSION_APPLIED,
-													{
-														versionAgeInDays:
-															getTimestampAgeInDays(
-																version.createdAt,
-															),
-													},
-												);
-											};
+					<Stack
+						width="100%"
+						flexShrink={0}
+						gap={0}
+						style={{
+							height: virtualizer.getTotalSize(),
+							paddingTop: virtualizer.getVirtualItems()[0]?.start ?? 0,
+						}}
+					>
+						{virtualizer.getVirtualItems().map((virtualRow) => {
+							const version = versions[virtualRow.index];
 
-											// Apply immediately
-											if (evt.ctrlKey || evt.metaKey) {
-												applyVersion();
-												return;
-											}
-
-											confirm(({ onClose }) => ({
-												title: t(
-													'note.versions.confirmApply.title',
-												),
-												content: (
-													<VStack gap="1rem" align="start">
-														<Text>
-															<Trans
-																i18nKey="note.versions.confirmApply.description"
-																ns={
-																	LOCALE_NAMESPACE.features
-																}
-																values={{
-																	version:
-																		formatNoteVersionPreview(
-																			version,
-																		),
-																}}
-																components={{
-																	secondary: (
-																		<Text
-																			as="span"
-																			variant="secondary"
-																		/>
-																	),
-																}}
-															/>
-														</Text>
-														<Text>
-															{t(
-																'note.versions.confirmApply.warning',
-															)}
-														</Text>
-													</VStack>
-												),
-												action: (
-													<>
-														<Button
-															variant="accent"
-															onClick={() => {
-																applyVersion();
-																onClose();
-															}}
-														>
-															{t(
-																'note.versions.confirmApply.apply',
-															)}
-														</Button>
-														<Button
-															variant="accent"
-															onClick={() => {
-																onShowVersion(version);
-																onClose();
-															}}
-														>
-															{t(
-																'note.versions.confirmApply.preview',
-															)}
-														</Button>
-														<Button onClick={onClose}>
-															{t('common:actions.cancel')}
-														</Button>
-													</>
-												),
-											}));
-										}}
-									>
-										<FaCheck />
-									</Button>
-
-									<Button
-										size="xs"
-										title={t('note.version.open.title')}
-										onClick={() => {
-											onShowVersion(version);
-
-											telemetry.track(
-												TELEMETRY_EVENT_NAME.NOTE_VERSION_VIEWED,
-												{
-													versionAgeInDays:
-														getTimestampAgeInDays(
-															version.createdAt,
-														),
-												},
-											);
-										}}
-									>
-										<FaGlasses />
-									</Button>
-									<Button
-										size="xs"
-										title={t('note.version.delete.title')}
-										onClick={(evt) => {
-											const deleteVersion = async () => {
-												await noteHistory.delete([version.id]);
-												eventBus.emit(
-													WorkspaceEvents.NOTE_HISTORY_UPDATED,
-													noteId,
-												);
-
-												telemetry.track(
-													TELEMETRY_EVENT_NAME.NOTE_VERSION_DELETED,
-													{
-														versionAgeInDays:
-															getTimestampAgeInDays(
-																version.createdAt,
-															),
-													},
-												);
-											};
-
-											// Delete immediately
-											if (evt.ctrlKey || evt.metaKey) {
-												deleteVersion();
-												return;
-											}
-
-											confirm(({ onClose }) => ({
-												title: t(
-													'note.versions.confirmDelete.title',
-												),
-												content: (
-													<VStack gap="1rem" align="start">
-														<Text>
-															<Trans
-																i18nKey="note.versions.confirmDelete.description"
-																ns={
-																	LOCALE_NAMESPACE.features
-																}
-																values={{
-																	version:
-																		formatNoteVersionPreview(
-																			version,
-																		),
-																}}
-																components={{
-																	secondary: (
-																		<Text
-																			as="span"
-																			variant="secondary"
-																		/>
-																	),
-																}}
-															/>
-														</Text>
-														<Text>
-															{t(
-																'note.versions.confirmDelete.warning',
-															)}
-														</Text>
-													</VStack>
-												),
-												action: (
-													<>
-														<Button
-															variant="accent"
-															onClick={() => {
-																deleteVersion();
-																onClose();
-															}}
-														>
-															{t(
-																'note.versions.confirmDelete.delete',
-															)}
-														</Button>
-														<Button
-															variant="accent"
-															onClick={() => {
-																onShowVersion(version);
-																onClose();
-															}}
-														>
-															{t(
-																'note.versions.confirmDelete.preview',
-															)}
-														</Button>
-														<Button onClick={onClose}>
-															{t('common:actions.cancel')}
-														</Button>
-													</>
-												),
-											}));
-										}}
-									>
-										<FaTrashCan />
-									</Button>
-								</HStack>
-							</HStack>
-						))}
-					</VStack>
+							return (
+								<NoteVersionItem
+									ref={virtualizer.measureElement}
+									key={virtualRow.index}
+									data-index={virtualRow.index}
+									version={version}
+									onApply={onApply(version)}
+									onPreview={onShow(version)}
+									onDelete={onDelete(version)}
+									isReadOnly={isReadOnly}
+								/>
+							);
+						})}
+					</Stack>
 				)}
 			</Box>
 		</VStack>

--- a/packages/app/src/features/NoteEditor/NoteVersions/NoteVersionItem.tsx
+++ b/packages/app/src/features/NoteEditor/NoteVersions/NoteVersionItem.tsx
@@ -1,0 +1,73 @@
+import React, { forwardRef, memo } from 'react';
+import { useTranslation } from 'react-i18next';
+import { FaCheck, FaGlasses, FaTrashCan } from 'react-icons/fa6';
+import { LOCALE_NAMESPACE } from 'src/i18n';
+import { Button, HStack, StackProps, Text } from '@chakra-ui/react';
+import { NoteVersion } from '@core/features/notes/history/NoteVersions';
+
+export const NoteVersionItem = memo(
+	forwardRef<
+		HTMLDivElement,
+		StackProps & {
+			version: NoteVersion;
+			isReadOnly?: boolean;
+			onDelete: () => void;
+			onApply: () => void;
+			onPreview: () => void;
+		}
+	>(({ version, isReadOnly, onPreview, onApply, onDelete, ...props }, ref) => {
+		const { t } = useTranslation(LOCALE_NAMESPACE.features);
+
+		return (
+			<HStack
+				ref={ref}
+				w="100%"
+				align="start"
+				padding="0.3rem"
+				alignItems="center"
+				_hover={{ backgroundColor: 'dim.50' }}
+				{...props}
+			>
+				<HStack>
+					<Text>{new Date(version.createdAt).toLocaleString()}</Text>
+					<Text variant="secondary">
+						{t('note.version.chars', {
+							count: version.text.length,
+						})}
+					</Text>
+				</HStack>
+				<HStack marginLeft="auto">
+					<Button
+						disabled={Boolean(isReadOnly)}
+						size="xs"
+						title={
+							isReadOnly
+								? t('note.version.apply.readonlyTitle')
+								: t('note.version.apply.title')
+						}
+						onClick={onApply}
+					>
+						<FaCheck />
+					</Button>
+
+					<Button
+						size="xs"
+						title={t('note.version.open.title')}
+						onClick={onPreview}
+					>
+						<FaGlasses />
+					</Button>
+					<Button
+						size="xs"
+						title={t('note.version.delete.title')}
+						onClick={onDelete}
+					>
+						<FaTrashCan />
+					</Button>
+				</HStack>
+			</HStack>
+		);
+	}),
+);
+
+NoteVersionItem.displayName = 'NoteVersionItem';

--- a/packages/app/src/features/NoteEditor/NoteVersions/NoteVersions.tsx
+++ b/packages/app/src/features/NoteEditor/NoteVersions/NoteVersions.tsx
@@ -1,27 +1,16 @@
-import React, { useCallback, useEffect, useRef, useState } from 'react';
-import { Trans, useTranslation } from 'react-i18next';
+import React, { useCallback, useEffect, useState } from 'react';
+import { useTranslation } from 'react-i18next';
 import { FaEraser, FaFloppyDisk } from 'react-icons/fa6';
 import { LOCALE_NAMESPACE } from 'src/i18n';
 import { WorkspaceEvents } from '@api/events/workspace';
-import { Box, Button, HStack, Stack, Switch, Text, VStack } from '@chakra-ui/react';
+import { Box, Button, HStack, Switch, Text, VStack } from '@chakra-ui/react';
 import { BoxWithCenteredContent } from '@components/BoxWithCenteredContent';
 import { TextWithIcon } from '@components/TextWithIcon';
 import { NoteVersion } from '@core/features/notes/history/NoteVersions';
-import { TELEMETRY_EVENT_NAME } from '@core/features/telemetry';
 import { useEventBus, useNotesHistory } from '@features/App/Workspace/WorkspaceProvider';
-import { useMemoizedCallback } from '@features/MainScreen/TagsPanel/useMemoizedCallback';
-import { useTelemetryTracker } from '@features/telemetry';
 import { useConfirmDialog } from '@hooks/useConfirmDialog';
-import { useVirtualizer } from '@tanstack/react-virtual';
 
-import { NoteVersionItem } from './NoteVersionItem';
-
-const ONE_DAY_IN_MS = 1000 * 60 * 60 * 24;
-const timestampToDays = (ms: number) => Math.floor(ms / ONE_DAY_IN_MS);
-const getTimestampAgeInDays = (ms: number) => timestampToDays(Date.now() - ms);
-
-export const formatNoteVersionPreview = (version: NoteVersion) =>
-	`${new Date(version.createdAt).toLocaleString()} (${version.text.length} chars)`;
+import { NoteVersionsList } from './NoteVersionsList';
 
 // TODO: implement lazy loading
 export const NoteVersions = ({
@@ -45,7 +34,6 @@ export const NoteVersions = ({
 	isReadOnly?: boolean;
 }) => {
 	const { t } = useTranslation(LOCALE_NAMESPACE.features);
-	const telemetry = useTelemetryTracker();
 	const noteHistory = useNotesHistory();
 
 	const [versions, setVersions] = useState<NoteVersion[] | null>(null);
@@ -69,154 +57,6 @@ export const NoteVersions = ({
 	}, [eventBus, updateVersionsList]);
 
 	const confirm = useConfirmDialog();
-	const listRootRef = useRef<HTMLDivElement>(null);
-
-	const onApply = useMemoizedCallback(
-		useCallback(
-			(version: NoteVersion) => {
-				const applyVersion = () => {
-					onVersionApply(version);
-					telemetry.track(TELEMETRY_EVENT_NAME.NOTE_VERSION_APPLIED, {
-						versionAgeInDays: getTimestampAgeInDays(version.createdAt),
-					});
-				};
-
-				confirm(({ onClose }) => ({
-					title: t('note.versions.confirmApply.title'),
-					content: (
-						<VStack gap="1rem" align="start">
-							<Text>
-								<Trans
-									i18nKey="note.versions.confirmApply.description"
-									ns={LOCALE_NAMESPACE.features}
-									values={{
-										version: formatNoteVersionPreview(version),
-									}}
-									components={{
-										secondary: <Text as="span" variant="secondary" />,
-									}}
-								/>
-							</Text>
-							<Text>{t('note.versions.confirmApply.warning')}</Text>
-						</VStack>
-					),
-					action: (
-						<>
-							<Button
-								variant="accent"
-								onClick={() => {
-									applyVersion();
-									onClose();
-								}}
-							>
-								{t('note.versions.confirmApply.apply')}
-							</Button>
-							<Button
-								variant="accent"
-								onClick={() => {
-									onShowVersion(version);
-									onClose();
-								}}
-							>
-								{t('note.versions.confirmApply.preview')}
-							</Button>
-							<Button onClick={onClose}>
-								{t('common:actions.cancel')}
-							</Button>
-						</>
-					),
-				}));
-			},
-			[confirm, onShowVersion, onVersionApply, t, telemetry],
-		),
-	);
-
-	const onShow = useMemoizedCallback(
-		useCallback(
-			(version: NoteVersion) => {
-				console.log('onShow click');
-				onShowVersion(version);
-
-				telemetry.track(TELEMETRY_EVENT_NAME.NOTE_VERSION_VIEWED, {
-					versionAgeInDays: getTimestampAgeInDays(version.createdAt),
-				});
-			},
-			[onShowVersion, telemetry],
-		),
-	);
-
-	const onDelete = useMemoizedCallback(
-		useCallback(
-			(version: NoteVersion) => {
-				const deleteVersion = async () => {
-					await noteHistory.delete([version.id]);
-					eventBus.emit(WorkspaceEvents.NOTE_HISTORY_UPDATED, noteId);
-
-					telemetry.track(TELEMETRY_EVENT_NAME.NOTE_VERSION_DELETED, {
-						versionAgeInDays: getTimestampAgeInDays(version.createdAt),
-					});
-				};
-
-				confirm(({ onClose }) => ({
-					title: t('note.versions.confirmDelete.title'),
-					content: (
-						<VStack gap="1rem" align="start">
-							<Text>
-								<Trans
-									i18nKey="note.versions.confirmDelete.description"
-									ns={LOCALE_NAMESPACE.features}
-									values={{
-										version: formatNoteVersionPreview(version),
-									}}
-									components={{
-										secondary: <Text as="span" variant="secondary" />,
-									}}
-								/>
-							</Text>
-							<Text>{t('note.versions.confirmDelete.warning')}</Text>
-						</VStack>
-					),
-					action: (
-						<>
-							<Button
-								variant="accent"
-								onClick={() => {
-									deleteVersion();
-									onClose();
-								}}
-							>
-								{t('note.versions.confirmDelete.delete')}
-							</Button>
-							<Button
-								variant="accent"
-								onClick={() => {
-									onShowVersion(version);
-									onClose();
-								}}
-							>
-								{t('note.versions.confirmDelete.preview')}
-							</Button>
-							<Button onClick={onClose}>
-								{t('common:actions.cancel')}
-							</Button>
-						</>
-					),
-				}));
-			},
-			[confirm, eventBus, noteHistory, noteId, onShowVersion, t, telemetry],
-		),
-	);
-
-	// FIXME: https://github.com/TanStack/virtual/issues/1119
-	// eslint-disable-next-line react-hooks/incompatible-library
-	const virtualizer = useVirtualizer({
-		count: versions?.length ?? 0,
-		getScrollElement: () => listRootRef.current,
-		estimateSize: () => 20,
-		overscan: 6,
-		useFlushSync: false,
-		useCachedMeasurements: true,
-	});
 
 	return (
 		<VStack w="100%" maxH="100%">
@@ -299,14 +139,7 @@ export const NoteVersions = ({
 					</label>
 				</HStack>
 			</HStack>
-			<Box
-				ref={listRootRef}
-				width="100%"
-				overflow="auto"
-				display="flex"
-				flex={1}
-				flexFlow="column"
-			>
+			<Box width="100%" overflow="auto" display="flex" flex={1} flexFlow="column">
 				{versions && versions.length === 0 && (
 					<BoxWithCenteredContent>
 						<Text fontSize="1.3rem">{t('note.versions.empty')}</Text>
@@ -318,32 +151,13 @@ export const NoteVersions = ({
 					</BoxWithCenteredContent>
 				)}
 				{versions !== null && versions.length > 0 && (
-					<Stack
-						width="100%"
-						flexShrink={0}
-						gap={0}
-						style={{
-							height: virtualizer.getTotalSize(),
-							paddingTop: virtualizer.getVirtualItems()[0]?.start ?? 0,
-						}}
-					>
-						{virtualizer.getVirtualItems().map((virtualRow) => {
-							const version = versions[virtualRow.index];
-
-							return (
-								<NoteVersionItem
-									ref={virtualizer.measureElement}
-									key={virtualRow.index}
-									data-index={virtualRow.index}
-									version={version}
-									onApply={onApply(version)}
-									onPreview={onShow(version)}
-									onDelete={onDelete(version)}
-									isReadOnly={isReadOnly}
-								/>
-							);
-						})}
-					</Stack>
+					<NoteVersionsList
+						noteId={noteId}
+						versions={versions}
+						onShowVersion={onShowVersion}
+						onVersionApply={onVersionApply}
+						isReadOnly={isReadOnly}
+					/>
 				)}
 			</Box>
 		</VStack>

--- a/packages/app/src/features/NoteEditor/NoteVersions/NoteVersions.tsx
+++ b/packages/app/src/features/NoteEditor/NoteVersions/NoteVersions.tsx
@@ -1,18 +1,9 @@
-import React, { forwardRef, memo, useCallback, useEffect, useRef, useState } from 'react';
+import React, { useCallback, useEffect, useRef, useState } from 'react';
 import { Trans, useTranslation } from 'react-i18next';
-import { FaCheck, FaEraser, FaFloppyDisk, FaGlasses, FaTrashCan } from 'react-icons/fa6';
+import { FaEraser, FaFloppyDisk } from 'react-icons/fa6';
 import { LOCALE_NAMESPACE } from 'src/i18n';
 import { WorkspaceEvents } from '@api/events/workspace';
-import {
-	Box,
-	Button,
-	HStack,
-	Stack,
-	StackProps,
-	Switch,
-	Text,
-	VStack,
-} from '@chakra-ui/react';
+import { Box, Button, HStack, Stack, Switch, Text, VStack } from '@chakra-ui/react';
 import { BoxWithCenteredContent } from '@components/BoxWithCenteredContent';
 import { TextWithIcon } from '@components/TextWithIcon';
 import { NoteVersion } from '@core/features/notes/history/NoteVersions';
@@ -23,79 +14,14 @@ import { useTelemetryTracker } from '@features/telemetry';
 import { useConfirmDialog } from '@hooks/useConfirmDialog';
 import { useVirtualizer } from '@tanstack/react-virtual';
 
+import { NoteVersionItem } from './NoteVersionItem';
+
 const ONE_DAY_IN_MS = 1000 * 60 * 60 * 24;
 const timestampToDays = (ms: number) => Math.floor(ms / ONE_DAY_IN_MS);
 const getTimestampAgeInDays = (ms: number) => timestampToDays(Date.now() - ms);
 
 export const formatNoteVersionPreview = (version: NoteVersion) =>
 	`${new Date(version.createdAt).toLocaleString()} (${version.text.length} chars)`;
-
-export const NoteVersionItem = memo(
-	forwardRef<
-		HTMLDivElement,
-		StackProps & {
-			version: NoteVersion;
-			isReadOnly?: boolean;
-			onDelete: () => void;
-			onApply: () => void;
-			onPreview: () => void;
-		}
-	>(({ version, isReadOnly, onPreview, onApply, onDelete, ...props }, ref) => {
-		const { t } = useTranslation(LOCALE_NAMESPACE.features);
-
-		return (
-			<HStack
-				ref={ref}
-				w="100%"
-				align="start"
-				padding="0.3rem"
-				alignItems="center"
-				_hover={{ backgroundColor: 'dim.50' }}
-				{...props}
-			>
-				<HStack>
-					<Text>{new Date(version.createdAt).toLocaleString()}</Text>
-					<Text variant="secondary">
-						{t('note.version.chars', {
-							count: version.text.length,
-						})}
-					</Text>
-				</HStack>
-				<HStack marginLeft="auto">
-					<Button
-						disabled={Boolean(isReadOnly)}
-						size="xs"
-						title={
-							isReadOnly
-								? t('note.version.apply.readonlyTitle')
-								: t('note.version.apply.title')
-						}
-						onClick={onApply}
-					>
-						<FaCheck />
-					</Button>
-
-					<Button
-						size="xs"
-						title={t('note.version.open.title')}
-						onClick={onPreview}
-					>
-						<FaGlasses />
-					</Button>
-					<Button
-						size="xs"
-						title={t('note.version.delete.title')}
-						onClick={onDelete}
-					>
-						<FaTrashCan />
-					</Button>
-				</HStack>
-			</HStack>
-		);
-	}),
-);
-
-NoteVersionItem.displayName = 'NoteVersionItem';
 
 // TODO: implement lazy loading
 export const NoteVersions = ({

--- a/packages/app/src/features/NoteEditor/NoteVersions/NoteVersions.tsx
+++ b/packages/app/src/features/NoteEditor/NoteVersions/NoteVersions.tsx
@@ -3,7 +3,7 @@ import { useTranslation } from 'react-i18next';
 import { FaEraser, FaFloppyDisk } from 'react-icons/fa6';
 import { LOCALE_NAMESPACE } from 'src/i18n';
 import { WorkspaceEvents } from '@api/events/workspace';
-import { Box, Button, HStack, Switch, Text, VStack } from '@chakra-ui/react';
+import { Box, Button, HStack, Spinner, Switch, Text, VStack } from '@chakra-ui/react';
 import { BoxWithCenteredContent } from '@components/BoxWithCenteredContent';
 import { TextWithIcon } from '@components/TextWithIcon';
 import { NoteVersion } from '@core/features/notes/history/NoteVersions';
@@ -147,7 +147,7 @@ export const NoteVersions = ({
 				)}
 				{versions === null && (
 					<BoxWithCenteredContent>
-						<Text fontSize="1.3rem">{t('note.versions.loading')}</Text>
+						<Spinner />
 					</BoxWithCenteredContent>
 				)}
 				{versions !== null && versions.length > 0 && (

--- a/packages/app/src/features/NoteEditor/NoteVersions/NoteVersions.tsx
+++ b/packages/app/src/features/NoteEditor/NoteVersions/NoteVersions.tsx
@@ -50,11 +50,11 @@ export const NoteVersions = ({
 	// Refresh note versions by event
 	const eventBus = useEventBus();
 	useEffect(() => {
-		return eventBus.listen(WorkspaceEvents.NOTE_HISTORY_UPDATED, (noteId) => {
-			if (noteId !== noteId) return;
+		return eventBus.listen(WorkspaceEvents.NOTE_HISTORY_UPDATED, (updatedNoteId) => {
+			if (updatedNoteId !== noteId) return;
 			updateVersionsList();
 		});
-	}, [eventBus, updateVersionsList]);
+	}, [eventBus, noteId, updateVersionsList]);
 
 	const confirm = useConfirmDialog();
 

--- a/packages/app/src/features/NoteEditor/NoteVersions/NoteVersionsList.tsx
+++ b/packages/app/src/features/NoteEditor/NoteVersions/NoteVersionsList.tsx
@@ -185,7 +185,10 @@ export const NoteVersionsList = ({
 		count: versions?.length ?? 0,
 		getItemKey: (index) => versions[index].id,
 		getScrollElement: () => listRootRef.current,
-		estimateSize: useEstimateVirtualItemSize(listRootRef, { defaultSize: 20 }),
+		estimateSize: useEstimateVirtualItemSize(listRootRef, {
+			defaultSize: 20,
+			getItemKey: (index) => versions[index].id,
+		}),
 		overscan: 6,
 		useFlushSync: false,
 		useCachedMeasurements: true,

--- a/packages/app/src/features/NoteEditor/NoteVersions/NoteVersionsList.tsx
+++ b/packages/app/src/features/NoteEditor/NoteVersions/NoteVersionsList.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useMemo, useRef } from 'react';
+import React, { useCallback, useRef } from 'react';
 import { Trans, useTranslation } from 'react-i18next';
 import { LOCALE_NAMESPACE } from 'src/i18n';
 import { WorkspaceEvents } from '@api/events/workspace';
@@ -9,9 +9,9 @@ import { useEventBus, useNotesHistory } from '@features/App/Workspace/WorkspaceP
 import { useMemoizedCallback } from '@features/MainScreen/TagsPanel/useMemoizedCallback';
 import { useTelemetryTracker } from '@features/telemetry';
 import { useConfirmDialog } from '@hooks/useConfirmDialog';
+import { useEstimateVirtualItemSize } from '@hooks/useEstimateVirtualItemSize';
 import { useVirtualizer } from '@tanstack/react-virtual';
 
-import { estimateItemSize } from './estimateItemSize';
 import { NoteVersionItem } from './NoteVersionItem';
 
 const ONE_DAY_IN_MS = 1000 * 60 * 60 * 24;
@@ -184,10 +184,7 @@ export const NoteVersionsList = ({
 	const virtualizer = useVirtualizer({
 		count: versions?.length ?? 0,
 		getScrollElement: () => listRootRef.current,
-		estimateSize: useMemo(
-			() => estimateItemSize(listRootRef, { defaultSize: 20 }),
-			[],
-		),
+		estimateSize: useEstimateVirtualItemSize(listRootRef, { defaultSize: 20 }),
 		overscan: 6,
 		useFlushSync: false,
 		useCachedMeasurements: true,

--- a/packages/app/src/features/NoteEditor/NoteVersions/NoteVersionsList.tsx
+++ b/packages/app/src/features/NoteEditor/NoteVersions/NoteVersionsList.tsx
@@ -183,6 +183,7 @@ export const NoteVersionsList = ({
 	// eslint-disable-next-line react-hooks/incompatible-library
 	const virtualizer = useVirtualizer({
 		count: versions?.length ?? 0,
+		getItemKey: (index) => versions[index].id,
 		getScrollElement: () => listRootRef.current,
 		estimateSize: useEstimateVirtualItemSize(listRootRef, { defaultSize: 20 }),
 		overscan: 6,
@@ -215,7 +216,7 @@ export const NoteVersionsList = ({
 					return (
 						<NoteVersionItem
 							ref={virtualizer.measureElement}
-							key={virtualRow.index}
+							key={version.id}
 							data-index={virtualRow.index}
 							version={version}
 							onApply={onApply(version)}

--- a/packages/app/src/features/NoteEditor/NoteVersions/NoteVersionsList.tsx
+++ b/packages/app/src/features/NoteEditor/NoteVersions/NoteVersionsList.tsx
@@ -1,0 +1,234 @@
+import React, { useCallback, useMemo, useRef } from 'react';
+import { Trans, useTranslation } from 'react-i18next';
+import { LOCALE_NAMESPACE } from 'src/i18n';
+import { WorkspaceEvents } from '@api/events/workspace';
+import { Box, Button, Stack, Text, VStack } from '@chakra-ui/react';
+import { NoteVersion } from '@core/features/notes/history/NoteVersions';
+import { TELEMETRY_EVENT_NAME } from '@core/features/telemetry';
+import { useEventBus, useNotesHistory } from '@features/App/Workspace/WorkspaceProvider';
+import { useMemoizedCallback } from '@features/MainScreen/TagsPanel/useMemoizedCallback';
+import { useTelemetryTracker } from '@features/telemetry';
+import { useConfirmDialog } from '@hooks/useConfirmDialog';
+import { useVirtualizer } from '@tanstack/react-virtual';
+
+import { estimateItemSize } from './estimateItemSize';
+import { NoteVersionItem } from './NoteVersionItem';
+
+const ONE_DAY_IN_MS = 1000 * 60 * 60 * 24;
+const timestampToDays = (ms: number) => Math.floor(ms / ONE_DAY_IN_MS);
+const getTimestampAgeInDays = (ms: number) => timestampToDays(Date.now() - ms);
+
+export const formatNoteVersionPreview = (version: NoteVersion) =>
+	`${new Date(version.createdAt).toLocaleString()} (${version.text.length} chars)`;
+
+export const NoteVersionsList = ({
+	versions,
+	noteId,
+	onVersionApply,
+	onShowVersion,
+	isReadOnly,
+}: {
+	noteId: string;
+	versions: NoteVersion[];
+	onVersionApply: (version: NoteVersion) => void;
+	onShowVersion: (version: NoteVersion) => void;
+	isReadOnly?: boolean;
+}) => {
+	const { t } = useTranslation(LOCALE_NAMESPACE.features);
+	const telemetry = useTelemetryTracker();
+	const noteHistory = useNotesHistory();
+
+	const eventBus = useEventBus();
+
+	const confirm = useConfirmDialog();
+	const listRootRef = useRef<HTMLDivElement>(null);
+
+	const onApply = useMemoizedCallback(
+		useCallback(
+			(version: NoteVersion) => {
+				const applyVersion = () => {
+					onVersionApply(version);
+					telemetry.track(TELEMETRY_EVENT_NAME.NOTE_VERSION_APPLIED, {
+						versionAgeInDays: getTimestampAgeInDays(version.createdAt),
+					});
+				};
+
+				confirm(({ onClose }) => ({
+					title: t('note.versions.confirmApply.title'),
+					content: (
+						<VStack gap="1rem" align="start">
+							<Text>
+								<Trans
+									i18nKey="note.versions.confirmApply.description"
+									ns={LOCALE_NAMESPACE.features}
+									values={{
+										version: formatNoteVersionPreview(version),
+									}}
+									components={{
+										secondary: <Text as="span" variant="secondary" />,
+									}}
+								/>
+							</Text>
+							<Text>{t('note.versions.confirmApply.warning')}</Text>
+						</VStack>
+					),
+					action: (
+						<>
+							<Button
+								variant="accent"
+								onClick={() => {
+									applyVersion();
+									onClose();
+								}}
+							>
+								{t('note.versions.confirmApply.apply')}
+							</Button>
+							<Button
+								variant="accent"
+								onClick={() => {
+									onShowVersion(version);
+									onClose();
+								}}
+							>
+								{t('note.versions.confirmApply.preview')}
+							</Button>
+							<Button onClick={onClose}>
+								{t('common:actions.cancel')}
+							</Button>
+						</>
+					),
+				}));
+			},
+			[confirm, onShowVersion, onVersionApply, t, telemetry],
+		),
+	);
+
+	const onShow = useMemoizedCallback(
+		useCallback(
+			(version: NoteVersion) => {
+				console.log('onShow click');
+				onShowVersion(version);
+
+				telemetry.track(TELEMETRY_EVENT_NAME.NOTE_VERSION_VIEWED, {
+					versionAgeInDays: getTimestampAgeInDays(version.createdAt),
+				});
+			},
+			[onShowVersion, telemetry],
+		),
+	);
+
+	const onDelete = useMemoizedCallback(
+		useCallback(
+			(version: NoteVersion) => {
+				const deleteVersion = async () => {
+					await noteHistory.delete([version.id]);
+					eventBus.emit(WorkspaceEvents.NOTE_HISTORY_UPDATED, noteId);
+
+					telemetry.track(TELEMETRY_EVENT_NAME.NOTE_VERSION_DELETED, {
+						versionAgeInDays: getTimestampAgeInDays(version.createdAt),
+					});
+				};
+
+				confirm(({ onClose }) => ({
+					title: t('note.versions.confirmDelete.title'),
+					content: (
+						<VStack gap="1rem" align="start">
+							<Text>
+								<Trans
+									i18nKey="note.versions.confirmDelete.description"
+									ns={LOCALE_NAMESPACE.features}
+									values={{
+										version: formatNoteVersionPreview(version),
+									}}
+									components={{
+										secondary: <Text as="span" variant="secondary" />,
+									}}
+								/>
+							</Text>
+							<Text>{t('note.versions.confirmDelete.warning')}</Text>
+						</VStack>
+					),
+					action: (
+						<>
+							<Button
+								variant="accent"
+								onClick={() => {
+									deleteVersion();
+									onClose();
+								}}
+							>
+								{t('note.versions.confirmDelete.delete')}
+							</Button>
+							<Button
+								variant="accent"
+								onClick={() => {
+									onShowVersion(version);
+									onClose();
+								}}
+							>
+								{t('note.versions.confirmDelete.preview')}
+							</Button>
+							<Button onClick={onClose}>
+								{t('common:actions.cancel')}
+							</Button>
+						</>
+					),
+				}));
+			},
+			[confirm, eventBus, noteHistory, noteId, onShowVersion, t, telemetry],
+		),
+	);
+
+	// FIXME: https://github.com/TanStack/virtual/issues/1119
+	// eslint-disable-next-line react-hooks/incompatible-library
+	const virtualizer = useVirtualizer({
+		count: versions?.length ?? 0,
+		getScrollElement: () => listRootRef.current,
+		estimateSize: useMemo(
+			() => estimateItemSize(listRootRef, { defaultSize: 20 }),
+			[],
+		),
+		overscan: 6,
+		useFlushSync: false,
+		useCachedMeasurements: true,
+	});
+
+	return (
+		<Box
+			ref={listRootRef}
+			width="100%"
+			height="100%"
+			overflow="auto"
+			display="flex"
+			flex={1}
+			flexFlow="column"
+		>
+			<Stack
+				width="100%"
+				flexShrink={0}
+				gap={0}
+				style={{
+					height: virtualizer.getTotalSize(),
+					paddingTop: virtualizer.getVirtualItems()[0]?.start ?? 0,
+				}}
+			>
+				{virtualizer.getVirtualItems().map((virtualRow) => {
+					const version = versions[virtualRow.index];
+
+					return (
+						<NoteVersionItem
+							ref={virtualizer.measureElement}
+							key={virtualRow.index}
+							data-index={virtualRow.index}
+							version={version}
+							onApply={onApply(version)}
+							onPreview={onShow(version)}
+							onDelete={onDelete(version)}
+							isReadOnly={isReadOnly}
+						/>
+					);
+				})}
+			</Stack>
+		</Box>
+	);
+};

--- a/packages/app/src/features/NoteEditor/NoteVersions/estimateItemSize.tsx
+++ b/packages/app/src/features/NoteEditor/NoteVersions/estimateItemSize.tsx
@@ -1,0 +1,38 @@
+import { RefObject } from 'react';
+
+// TODO: add option `strategy` to control if return avg size or most recently measured, etc
+/**
+ * Util for virtual list to create instance for node size estimation
+ */
+export const estimateItemSize = <T extends unknown>(
+	elementRef: RefObject<T>,
+	{ defaultSize }: { defaultSize: number },
+) => {
+	const sizes = new Map<number, number>();
+	const getItemSize = (index: number) => {
+		// Try to return actual size from cache
+		const indexSize = sizes.get(index);
+		if (indexSize !== undefined) return indexSize;
+
+		// Try to guess probable size if have enough stats
+		const cachedSizes = sizes.values().take(1).toArray();
+		if (cachedSizes.length > 0) {
+			return cachedSizes[0];
+		}
+
+		return defaultSize;
+	};
+
+	return (index: number) => {
+		// Try to update size
+		const root = elementRef.current;
+		if (root && root instanceof HTMLElement) {
+			const item = root.querySelector(`[data-index="${index}"]`);
+			if (item) {
+				sizes.set(index, item.clientHeight);
+			}
+		}
+
+		return getItemSize(index);
+	};
+};

--- a/packages/app/src/features/NoteEditor/index.tsx
+++ b/packages/app/src/features/NoteEditor/index.tsx
@@ -63,7 +63,7 @@ import { wait } from '@utils/time';
 import { NoteEditor } from './NoteEditor';
 import { NoteMenu } from './NoteMenu';
 import { NoteSidebar } from './NoteSidebar';
-import { NoteVersions } from './NoteVersions';
+import { NoteVersions } from './NoteVersions/NoteVersions';
 import { useTogglePreviewTabToRegularOnChange } from './useTogglePreviewTabToRegularOnChange';
 
 export enum NoteSidebarTabs {

--- a/packages/app/src/hooks/useEstimateVirtualItemSize/estimateItemSize.ts
+++ b/packages/app/src/hooks/useEstimateVirtualItemSize/estimateItemSize.ts
@@ -1,6 +1,9 @@
 import { RefObject } from 'react';
 
-export type ItemSizeEstimatorOptions = { defaultSize: number };
+export type ItemSizeEstimatorOptions = {
+	defaultSize: number;
+	getItemKey?: (index: number) => string;
+};
 
 // TODO: add option `strategy` to control if return avg size or most recently measured, etc
 /**
@@ -8,14 +11,14 @@ export type ItemSizeEstimatorOptions = { defaultSize: number };
  */
 export const estimateItemSize = <T extends unknown>(
 	elementRef: RefObject<T>,
-	{ defaultSize }: ItemSizeEstimatorOptions,
+	{ defaultSize, getItemKey = String }: ItemSizeEstimatorOptions,
 ) => {
-	const sizes = new Map<number, number>();
+	const sizes = new Map<string, number>();
 	let maxSize = defaultSize;
 
 	const getItemSize = (index: number) => {
 		// Return actual size from cache if recorded
-		const indexSize = sizes.get(index);
+		const indexSize = sizes.get(getItemKey(index));
 		if (indexSize !== undefined) return indexSize;
 
 		return maxSize;
@@ -28,8 +31,8 @@ export const estimateItemSize = <T extends unknown>(
 			const item = root.querySelector(`[data-index="${index}"]`);
 			if (item) {
 				const itemSize = item.clientHeight;
-				if (itemSize !== sizes.get(index)) {
-					sizes.set(index, item.clientHeight);
+				if (itemSize !== sizes.get(getItemKey(index))) {
+					sizes.set(getItemKey(index), item.clientHeight);
 
 					// Update max size
 					if (itemSize > maxSize) maxSize = itemSize;

--- a/packages/app/src/hooks/useEstimateVirtualItemSize/estimateItemSize.ts
+++ b/packages/app/src/hooks/useEstimateVirtualItemSize/estimateItemSize.ts
@@ -11,18 +11,14 @@ export const estimateItemSize = <T extends unknown>(
 	{ defaultSize }: ItemSizeEstimatorOptions,
 ) => {
 	const sizes = new Map<number, number>();
+	let maxSize = defaultSize;
+
 	const getItemSize = (index: number) => {
-		// Try to return actual size from cache
+		// Return actual size from cache if recorded
 		const indexSize = sizes.get(index);
 		if (indexSize !== undefined) return indexSize;
 
-		// Try to guess probable size if have enough stats
-		const cachedSizes = sizes.values().take(1).toArray();
-		if (cachedSizes.length > 0) {
-			return cachedSizes[0];
-		}
-
-		return defaultSize;
+		return maxSize;
 	};
 
 	return (index: number) => {
@@ -31,7 +27,13 @@ export const estimateItemSize = <T extends unknown>(
 		if (root && root instanceof HTMLElement) {
 			const item = root.querySelector(`[data-index="${index}"]`);
 			if (item) {
-				sizes.set(index, item.clientHeight);
+				const itemSize = item.clientHeight;
+				if (itemSize !== sizes.get(index)) {
+					sizes.set(index, item.clientHeight);
+
+					// Update max size
+					if (itemSize > maxSize) maxSize = itemSize;
+				}
 			}
 		}
 

--- a/packages/app/src/hooks/useEstimateVirtualItemSize/estimateItemSize.ts
+++ b/packages/app/src/hooks/useEstimateVirtualItemSize/estimateItemSize.ts
@@ -1,12 +1,14 @@
 import { RefObject } from 'react';
 
+export type ItemSizeEstimatorOptions = { defaultSize: number };
+
 // TODO: add option `strategy` to control if return avg size or most recently measured, etc
 /**
  * Util for virtual list to create instance for node size estimation
  */
 export const estimateItemSize = <T extends unknown>(
 	elementRef: RefObject<T>,
-	{ defaultSize }: { defaultSize: number },
+	{ defaultSize }: ItemSizeEstimatorOptions,
 ) => {
 	const sizes = new Map<number, number>();
 	const getItemSize = (index: number) => {

--- a/packages/app/src/hooks/useEstimateVirtualItemSize/index.ts
+++ b/packages/app/src/hooks/useEstimateVirtualItemSize/index.ts
@@ -1,0 +1,10 @@
+import { RefObject, useMemo } from 'react';
+
+import { estimateItemSize, ItemSizeEstimatorOptions } from './estimateItemSize';
+
+export const useEstimateVirtualItemSize = <T>(
+	elementRef: RefObject<T>,
+	options: ItemSizeEstimatorOptions,
+) => {
+	return useMemo(() => estimateItemSize(elementRef, options), [elementRef, options]);
+};

--- a/packages/app/src/locales/en/features.json
+++ b/packages/app/src/locales/en/features.json
@@ -142,7 +142,6 @@
 			},
 			"dontRecord": "Don't record history for this note",
 			"empty": "This note has no recorded versions",
-			"loading": "Loading...",
 			"confirmDeleteAll": {
 				"title": "Delete all note versions",
 				"description": "This action will permanently delete all note versions.",


### PR DESCRIPTION
Closes #321

Now we use a virtual list and render only dozen or a few dozens of versions.

Now first render takes 100ms, and scrolling takes about 20-30ms so it feels smooth.

## Side changes

In that PR I've implement the `useEstimateVirtualItemSize` hook for better size estimation in virtual lists, and that hook is used for `NotesList` component.

If any bugs will appear, check that change first. For now it seems stable.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Updated the virtual scrolling library used for note history.

* **Refactor**
  * Reorganized the note versions sidebar into a new, virtualized list layout with reusable version items.
  * Improved virtual list item sizing using dynamic height estimation for smoother scrolling.

* **Style**
  * Updated how loading text is handled in the note versions experience.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->