### PR TITLE
fix: RichEditor: Can't remove empty quote placed at start of document

### DIFF
--- a/packages/app/scripts/vitest.setup.ts
+++ b/packages/app/scripts/vitest.setup.ts
@@ -26,4 +26,9 @@ if (isDOMLikeEnv) {
 		y: 0,
 		toJSON: () => {},
 	});
+
+	Object.defineProperty(Selection.prototype, 'modify', {
+		value: vi.fn(),
+		configurable: true,
+	});
 }

--- a/packages/app/src/features/NoteEditor/RichEditor/__tests__/spec/blockquote.dom.test.ts
+++ b/packages/app/src/features/NoteEditor/RichEditor/__tests__/spec/blockquote.dom.test.ts
@@ -4,7 +4,7 @@ import userEvent from '@testing-library/user-event';
 import { renderRichEditor } from '../utils/renderRichEditor';
 import { selectContent } from '../utils/utils';
 
-test('Insert blockquote', async () => {
+test('Wrap text in a blockquote', async () => {
 	const richEditor = await renderRichEditor({ value: 'cat' });
 
 	const editor = screen.getByRole('textbox');
@@ -21,7 +21,7 @@ test('Insert blockquote', async () => {
 	expect(quotes[1]).toHaveTextContent('cat');
 });
 
-test('Empty blockquote is removed when backspace is pressed', async () => {
+test('Removes an empty blockquote when backspace is pressed', async () => {
 	const user = userEvent.setup();
 	await renderRichEditor({ value: '>' });
 
@@ -35,17 +35,19 @@ test('Empty blockquote is removed when backspace is pressed', async () => {
 	expect(within(editor).queryByRole('paragraph')).toHaveTextContent('');
 });
 
-test('Blockquote with text is removed when backspace is pressed', async () => {
+test('Removes a blockquote after deleting its text with Backspace', async () => {
 	const user = userEvent.setup();
 	await renderRichEditor({ value: '> text' });
 
 	const editor = screen.getByRole('textbox');
 	const quote = within(editor).getByRole('blockquote');
+	expect(quote).toHaveTextContent('text');
 
+	// Select the text for deletion
 	await user.click(quote);
 	selectContent(quote, 'text');
 
-	// First delete text, then blockquote
+	// First press deletes the text, second press removes the blockquote
 	await user.keyboard('{Backspace}');
 	await user.keyboard('{Backspace}');
 
@@ -53,27 +55,29 @@ test('Blockquote with text is removed when backspace is pressed', async () => {
 	expect(within(editor).queryByText('text')).not.toBeInTheDocument();
 });
 
-test('Removed nested blockquote', async () => {
+test('Removes nested blockquote one level at a time on Backspace', async () => {
 	const user = userEvent.setup();
-	await renderRichEditor({ value: '>>' });
+	await renderRichEditor({ value: '>>>' });
 
 	const editor = screen.getByRole('textbox');
 	const quotes = within(editor).getAllByRole('blockquote');
-	expect(quotes).toHaveLength(2);
+	expect(quotes).toHaveLength(3);
 
-	// Delete nested quote
-	await user.click(quotes[1]);
+	// Delete the nested blockquote
+	await user.click(quotes[2]);
 	await user.keyboard('{Backspace}');
 
-	expect(quotes[1]).not.toBeInTheDocument();
-	expect(within(editor).getAllByRole('blockquote')).toHaveLength(1);
+	expect(quotes[2]).not.toBeInTheDocument();
+	expect(within(editor).getAllByRole('blockquote')).toHaveLength(2);
 
-	// Delete external quote
+	await user.keyboard('{Backspace}');
+	expect(within(editor).queryAllByRole('blockquote')).toHaveLength(1);
+
 	await user.keyboard('{Backspace}');
 	expect(within(editor).queryAllByRole('blockquote')).toHaveLength(0);
 });
 
-test('Removes nested blockquote after deleting its text with backspace', async () => {
+test('Removes an empty nested blockquote on backspace after deleting its text', async () => {
 	const user = userEvent.setup();
 	await renderRichEditor({ value: `> foo\n>> bar` });
 
@@ -84,19 +88,14 @@ test('Removes nested blockquote after deleting its text with backspace', async (
 	await user.click(quotes[1]);
 	selectContent(quotes[1], 'bar');
 
-	// First remove the text
+	// Delete the text
 	await user.keyboard('{Backspace}');
-	expect(within(editor).queryByText('bar')).not.toBeInTheDocument();
+	expect(quotes[1]).toHaveTextContent('');
+	expect(within(editor).getAllByRole('blockquote')).toHaveLength(2);
 
-	// Second press remove the blockquote
+	// The second press should remove the blockquote
 	await user.keyboard('{Backspace}');
+
 	expect(within(editor).getAllByRole('blockquote')).toHaveLength(1);
-
-	selectContent(quotes[0], 'foo');
-
-	await user.keyboard('{Backspace}');
-	await user.keyboard('{Backspace}');
-
-	expect(within(editor).queryByText('foo')).not.toBeInTheDocument();
-	expect(within(editor).queryByRole('blockquote')).not.toBeInTheDocument();
+	expect(within(editor).getByRole('blockquote')).toHaveTextContent('foo');
 });

--- a/packages/app/src/features/NoteEditor/RichEditor/__tests__/spec/blockquote.dom.test.ts
+++ b/packages/app/src/features/NoteEditor/RichEditor/__tests__/spec/blockquote.dom.test.ts
@@ -4,7 +4,24 @@ import userEvent from '@testing-library/user-event';
 import { renderRichEditor } from '../utils/renderRichEditor';
 import { selectContent } from '../utils/utils';
 
-test('Blockquote is removed when backspace is pressed', async () => {
+test('Insert blockquote', async () => {
+	const richEditor = await renderRichEditor({ value: 'cat' });
+
+	const editor = screen.getByRole('textbox');
+	selectContent(editor, 'cat');
+	await richEditor.insert({ type: 'quote' });
+
+	expect(within(editor).getByRole('blockquote')).toHaveTextContent('cat');
+
+	selectContent(editor, 'cat');
+	await richEditor.insert({ type: 'quote' });
+
+	const quotes = within(editor).getAllByRole('blockquote');
+	expect(quotes).toHaveLength(2);
+	expect(quotes[1]).toHaveTextContent('cat');
+});
+
+test('Empty blockquote is removed when backspace is pressed', async () => {
 	const user = userEvent.setup();
 	await renderRichEditor({ value: '>' });
 

--- a/packages/app/src/features/NoteEditor/RichEditor/__tests__/spec/blockquote.dom.test.ts
+++ b/packages/app/src/features/NoteEditor/RichEditor/__tests__/spec/blockquote.dom.test.ts
@@ -56,35 +56,30 @@ test('Removed nested blockquote', async () => {
 	expect(within(editor).queryAllByRole('blockquote')).toHaveLength(0);
 });
 
-test.fails(
-	'deletes nested empty blockquote on backspace instead of jumping cursor to previous line',
-	async () => {
-		const user = userEvent.setup();
-		await renderRichEditor({ value: `> foo\n>> bar` });
+test('Removes nested blockquote after deleting its text with backspace', async () => {
+	const user = userEvent.setup();
+	await renderRichEditor({ value: `> foo\n>> bar` });
 
-		const editor = screen.getByRole('textbox');
-		let quotes = within(editor).getAllByRole('blockquote');
-		expect(quotes).toHaveLength(2);
+	const editor = screen.getByRole('textbox');
+	const quotes = within(editor).getAllByRole('blockquote');
+	expect(quotes).toHaveLength(2);
 
-		await user.click(quotes[1]);
-		selectContent(quotes[1], 'bar');
+	await user.click(quotes[1]);
+	selectContent(quotes[1], 'bar');
 
-		await user.keyboard('{Backspace}');
-		await user.keyboard('{Backspace}');
+	// First remove the text
+	await user.keyboard('{Backspace}');
+	expect(within(editor).queryByText('bar')).not.toBeInTheDocument();
 
-		quotes = within(editor).getAllByRole('blockquote');
-		expect(quotes).toHaveLength(2);
-		expect(quotes[1]).toHaveTextContent('');
+	// Second press remove the blockquote
+	await user.keyboard('{Backspace}');
+	expect(within(editor).getAllByRole('blockquote')).toHaveLength(1);
 
-		await user.keyboard('{Backspace}');
+	selectContent(quotes[0], 'foo');
 
-		quotes = within(editor).getAllByRole('blockquote');
+	await user.keyboard('{Backspace}');
+	await user.keyboard('{Backspace}');
 
-		expect(quotes).toHaveLength(1);
-		expect(editor).toHaveTextContent('foo');
-
-		const selection = window.getSelection();
-		expect(selection?.anchorNode?.textContent).toBe('foo');
-		expect(selection?.anchorOffset).toBe(3);
-	},
-);
+	expect(within(editor).queryByText('foo')).not.toBeInTheDocument();
+	expect(within(editor).queryByRole('blockquote')).not.toBeInTheDocument();
+});

--- a/packages/app/src/features/NoteEditor/RichEditor/__tests__/spec/blockquote.dom.test.ts
+++ b/packages/app/src/features/NoteEditor/RichEditor/__tests__/spec/blockquote.dom.test.ts
@@ -1,0 +1,90 @@
+import { screen, within } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+
+import { renderRichEditor } from '../utils/renderRichEditor';
+import { selectContent } from '../utils/utils';
+
+test('Blockquote is removed when backspace is pressed', async () => {
+	const user = userEvent.setup();
+	await renderRichEditor({ value: '>' });
+
+	const editor = screen.getByRole('textbox');
+	const quote = within(editor).getByRole('blockquote');
+
+	await user.click(quote);
+	await user.keyboard('{Backspace}');
+
+	expect(within(editor).queryByRole('blockquote')).not.toBeInTheDocument();
+	expect(within(editor).queryByRole('paragraph')).toHaveTextContent('');
+});
+
+test('Blockquote with text is removed when backspace is pressed', async () => {
+	const user = userEvent.setup();
+	await renderRichEditor({ value: '> text' });
+
+	const editor = screen.getByRole('textbox');
+	const quote = within(editor).getByRole('blockquote');
+
+	await user.click(quote);
+	selectContent(quote, 'text');
+
+	// First delete text, then blockquote
+	await user.keyboard('{Backspace}');
+	await user.keyboard('{Backspace}');
+
+	expect(within(editor).queryByRole('blockquote')).not.toBeInTheDocument();
+	expect(within(editor).queryByText('text')).not.toBeInTheDocument();
+});
+
+test('Removed nested blockquote', async () => {
+	const user = userEvent.setup();
+	await renderRichEditor({ value: '>>' });
+
+	const editor = screen.getByRole('textbox');
+	const quotes = within(editor).getAllByRole('blockquote');
+	expect(quotes).toHaveLength(2);
+
+	// Delete nested quote
+	await user.click(quotes[1]);
+	await user.keyboard('{Backspace}');
+
+	expect(quotes[1]).not.toBeInTheDocument();
+	expect(within(editor).getAllByRole('blockquote')).toHaveLength(1);
+
+	// Delete external quote
+	await user.keyboard('{Backspace}');
+	expect(within(editor).queryAllByRole('blockquote')).toHaveLength(0);
+});
+
+test.fails(
+	'deletes nested empty blockquote on backspace instead of jumping cursor to previous line',
+	async () => {
+		const user = userEvent.setup();
+		await renderRichEditor({ value: `> foo\n>> bar` });
+
+		const editor = screen.getByRole('textbox');
+		let quotes = within(editor).getAllByRole('blockquote');
+		expect(quotes).toHaveLength(2);
+
+		await user.click(quotes[1]);
+		selectContent(quotes[1], 'bar');
+
+		await user.keyboard('{Backspace}');
+		await user.keyboard('{Backspace}');
+
+		quotes = within(editor).getAllByRole('blockquote');
+		expect(quotes).toHaveLength(2);
+		expect(quotes[1]).toHaveTextContent('');
+
+		await user.keyboard('{Backspace}');
+
+		quotes = within(editor).getAllByRole('blockquote');
+
+		expect(quotes).toHaveLength(1);
+		expect(editor).toHaveTextContent('foo');
+
+		const selection = window.getSelection();
+		expect(selection?.anchorNode?.textContent).toBe('foo');
+		expect(selection?.anchorOffset).toBe(3);
+	},
+);

--- a/packages/app/src/features/NoteEditor/RichEditor/__tests__/spec/blockquote.dom.test.ts
+++ b/packages/app/src/features/NoteEditor/RichEditor/__tests__/spec/blockquote.dom.test.ts
@@ -25,7 +25,6 @@ test('Removes an empty quote', async () => {
 	await user.keyboard('{Backspace}');
 
 	expect(within(editor).queryByRole('blockquote')).not.toBeInTheDocument();
-	expect(editor).toHaveTextContent('');
 });
 
 test('Removes a quote while preserving its text', async () => {
@@ -34,6 +33,7 @@ test('Removes a quote while preserving its text', async () => {
 
 	const editor = screen.getByRole('textbox');
 	const quote = within(editor).getByRole('blockquote');
+	expect(quote).toHaveTextContent('Bob');
 
 	// Set the cursor position at the start of the text
 	await user.click(quote);
@@ -72,6 +72,8 @@ test('Removes one quote nesting level at a time', async () => {
 	const editor = screen.getByRole('textbox');
 	const quotes = within(editor).getAllByRole('blockquote');
 	expect(quotes).toHaveLength(3);
+	expect(quotes[0]).toContainElement(quotes[1]);
+	expect(quotes[1]).toContainElement(quotes[2]);
 
 	await user.click(quotes[2]);
 	await user.keyboard('{Backspace}');
@@ -89,21 +91,24 @@ test('Removes an empty nested quote after deleting its text', async () => {
 	await renderRichEditor({ value: `> foo\n>> bar` });
 
 	const editor = screen.getByRole('textbox');
-	const quotes = within(editor).getAllByRole('blockquote');
-	expect(quotes).toHaveLength(2);
-
-	await user.click(quotes[1]);
-	selectContent(quotes[1], 'bar');
+	const initialQuotes = within(editor).getAllByRole('blockquote');
+	expect(initialQuotes).toHaveLength(2);
+	expect(initialQuotes[0]).toContainElement(initialQuotes[1]);
 
 	// Delete the text
+	await user.click(initialQuotes[1]);
+	selectContent(initialQuotes[1], 'bar');
 	await user.keyboard('{Backspace}');
-	expect(quotes[1]).toHaveTextContent('');
-	expect(within(editor).getAllByRole('blockquote')).toHaveLength(2);
+
+	const updatedQuotes = within(editor).getAllByRole('blockquote');
+	expect(updatedQuotes).toHaveLength(2);
+	expect(updatedQuotes[1]).toHaveTextContent('');
 
 	// The second press should remove the nested quote
 	await user.keyboard('{Backspace}');
-	expect(within(editor).getAllByRole('blockquote')).toHaveLength(1);
-	expect(within(editor).getByRole('blockquote')).toHaveTextContent('foo');
+	const finalQuotes = within(editor).getAllByRole('blockquote');
+	expect(finalQuotes).toHaveLength(1);
+	expect(finalQuotes[0]).toHaveTextContent('foo');
 });
 
 test('Reduces quote nesting level while preserving its text', async () => {
@@ -113,6 +118,7 @@ test('Reduces quote nesting level while preserving its text', async () => {
 	const editor = screen.getByRole('textbox');
 	const quotes = within(editor).getAllByRole('blockquote');
 	expect(quotes).toHaveLength(2);
+	expect(quotes[0]).toContainElement(quotes[1]);
 
 	// Set the cursor position at the start of the text
 	await user.click(quotes[1]);
@@ -121,7 +127,8 @@ test('Reduces quote nesting level while preserving its text', async () => {
 
 	expect(within(editor).getAllByRole('blockquote')).toHaveLength(1);
 
-	const [quote] = within(editor).getAllByRole('blockquote');
-	expect(quote).toHaveTextContent('foo');
-	expect(quote).toHaveTextContent('bar');
+	const updatedQuote = within(editor).getAllByRole('blockquote');
+	expect(updatedQuote).toHaveLength(1);
+	expect(updatedQuote[0]).toHaveTextContent('foo');
+	expect(updatedQuote[0]).toHaveTextContent('bar');
 });

--- a/packages/app/src/features/NoteEditor/RichEditor/__tests__/spec/blockquote.dom.test.ts
+++ b/packages/app/src/features/NoteEditor/RichEditor/__tests__/spec/blockquote.dom.test.ts
@@ -4,14 +4,25 @@ import userEvent from '@testing-library/user-event';
 import { renderRichEditor } from '../utils/renderRichEditor';
 import { selectContent, setCursorPosition } from '../utils/utils';
 
-test('Creates a quote from selected text', async () => {
-	const richEditor = await renderRichEditor({ value: 'cat' });
+test('Creates and removes quote', async () => {
+	const user = userEvent.setup();
+	const richEditor = await renderRichEditor({ value: 'One \n\n cat' });
 
 	const editor = screen.getByRole('textbox');
 	selectContent(editor, 'cat');
 	await richEditor.insert({ type: 'quote' });
 
 	expect(within(editor).getByRole('blockquote')).toHaveTextContent('cat');
+
+	// Set the cursor position at the start of the text
+	const quote = within(editor).getByRole('blockquote');
+	await user.click(quote);
+	setCursorPosition(quote, 0);
+	await user.keyboard('{Backspace}');
+
+	expect(within(editor).queryByRole('blockquote')).not.toBeInTheDocument();
+	expect(editor).toHaveTextContent('One');
+	expect(editor).toHaveTextContent('cat');
 });
 
 test('Removes an empty quote', async () => {
@@ -27,24 +38,7 @@ test('Removes an empty quote', async () => {
 	expect(within(editor).queryByRole('blockquote')).not.toBeInTheDocument();
 });
 
-test('Removes a quote while preserving its text', async () => {
-	const user = userEvent.setup();
-	await renderRichEditor({ value: '> Bob' });
-
-	const editor = screen.getByRole('textbox');
-	const quote = within(editor).getByRole('blockquote');
-	expect(quote).toHaveTextContent('Bob');
-
-	// Set the cursor position at the start of the text
-	await user.click(quote);
-	setCursorPosition(quote, 0);
-	await user.keyboard('{Backspace}');
-
-	expect(within(editor).queryByRole('blockquote')).not.toBeInTheDocument();
-	expect(editor).toHaveTextContent('Bob');
-});
-
-test('Removes an empty quote after deleting its text', async () => {
+test('Removes quote after deleting its text', async () => {
 	const user = userEvent.setup();
 	await renderRichEditor({ value: '> text' });
 
@@ -65,39 +59,18 @@ test('Removes an empty quote after deleting its text', async () => {
 	expect(within(editor).queryByRole('blockquote')).not.toBeInTheDocument();
 });
 
-test('Removes one quote nesting level at a time', async () => {
-	const user = userEvent.setup();
-	await renderRichEditor({ value: '>>>' });
-
-	const editor = screen.getByRole('textbox');
-	const quotes = within(editor).getAllByRole('blockquote');
-	expect(quotes).toHaveLength(3);
-	expect(quotes[0]).toContainElement(quotes[1]);
-	expect(quotes[1]).toContainElement(quotes[2]);
-
-	await user.click(quotes[2]);
-	await user.keyboard('{Backspace}');
-	expect(within(editor).getAllByRole('blockquote')).toHaveLength(2);
-
-	await user.keyboard('{Backspace}');
-	expect(within(editor).queryAllByRole('blockquote')).toHaveLength(1);
-
-	await user.keyboard('{Backspace}');
-	expect(within(editor).queryAllByRole('blockquote')).toHaveLength(0);
-});
-
-test('Removes an empty nested quote after deleting its text', async () => {
+test('Removes nested quote after deleting its text', async () => {
 	const user = userEvent.setup();
 	await renderRichEditor({ value: `> foo\n>> bar` });
 
 	const editor = screen.getByRole('textbox');
-	const initialQuotes = within(editor).getAllByRole('blockquote');
-	expect(initialQuotes).toHaveLength(2);
-	expect(initialQuotes[0]).toContainElement(initialQuotes[1]);
+	const quotes = within(editor).getAllByRole('blockquote');
+	expect(quotes).toHaveLength(2);
+	expect(quotes[0]).toContainElement(quotes[1]);
 
 	// Delete the text
-	await user.click(initialQuotes[1]);
-	selectContent(initialQuotes[1], 'bar');
+	await user.click(quotes[1]);
+	selectContent(quotes[1], 'bar');
 	await user.keyboard('{Backspace}');
 
 	const updatedQuotes = within(editor).getAllByRole('blockquote');
@@ -131,4 +104,25 @@ test('Reduces quote nesting level while preserving its text', async () => {
 	expect(updatedQuote).toHaveLength(1);
 	expect(updatedQuote[0]).toHaveTextContent('foo');
 	expect(updatedQuote[0]).toHaveTextContent('bar');
+});
+
+test('Removes one quote nesting level at a time', async () => {
+	const user = userEvent.setup();
+	await renderRichEditor({ value: '>>>' });
+
+	const editor = screen.getByRole('textbox');
+	const quotes = within(editor).getAllByRole('blockquote');
+	expect(quotes).toHaveLength(3);
+	expect(quotes[0]).toContainElement(quotes[1]);
+	expect(quotes[1]).toContainElement(quotes[2]);
+
+	await user.click(quotes[2]);
+	await user.keyboard('{Backspace}');
+	expect(within(editor).getAllByRole('blockquote')).toHaveLength(2);
+
+	await user.keyboard('{Backspace}');
+	expect(within(editor).queryAllByRole('blockquote')).toHaveLength(1);
+
+	await user.keyboard('{Backspace}');
+	expect(within(editor).queryAllByRole('blockquote')).toHaveLength(0);
 });

--- a/packages/app/src/features/NoteEditor/RichEditor/__tests__/spec/blockquote.dom.test.ts
+++ b/packages/app/src/features/NoteEditor/RichEditor/__tests__/spec/blockquote.dom.test.ts
@@ -2,9 +2,9 @@ import { screen, within } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 
 import { renderRichEditor } from '../utils/renderRichEditor';
-import { selectContent } from '../utils/utils';
+import { selectContent, setCursorPosition } from '../utils/utils';
 
-test('Wrap text in a blockquote', async () => {
+test('Creates a blockquote from selected text', async () => {
 	const richEditor = await renderRichEditor({ value: 'cat' });
 
 	const editor = screen.getByRole('textbox');
@@ -21,7 +21,7 @@ test('Wrap text in a blockquote', async () => {
 	expect(quotes[1]).toHaveTextContent('cat');
 });
 
-test('Removes an empty blockquote when backspace is pressed', async () => {
+test('Removes an empty blockquote when', async () => {
 	const user = userEvent.setup();
 	await renderRichEditor({ value: '>' });
 
@@ -35,7 +35,22 @@ test('Removes an empty blockquote when backspace is pressed', async () => {
 	expect(within(editor).queryByRole('paragraph')).toHaveTextContent('');
 });
 
-test('Removes a blockquote after deleting its text with Backspace', async () => {
+test('Removes a blockquote while preserving its text', async () => {
+	const user = userEvent.setup();
+	await renderRichEditor({ value: '> Bob' });
+
+	const editor = screen.getByRole('textbox');
+	const quote = within(editor).getByRole('blockquote');
+
+	await user.click(quote);
+	setCursorPosition(quote, 0);
+	await user.keyboard('{Backspace}');
+
+	expect(within(editor).queryByRole('blockquote')).not.toBeInTheDocument();
+	expect(editor).toHaveTextContent('Bob');
+});
+
+test('Removes a blockquote after its text is deleted', async () => {
 	const user = userEvent.setup();
 	await renderRichEditor({ value: '> text' });
 
@@ -55,7 +70,7 @@ test('Removes a blockquote after deleting its text with Backspace', async () => 
 	expect(within(editor).queryByText('text')).not.toBeInTheDocument();
 });
 
-test('Removes nested blockquote one level at a time on Backspace', async () => {
+test('Removes one blockquote nesting level at a time', async () => {
 	const user = userEvent.setup();
 	await renderRichEditor({ value: '>>>' });
 
@@ -77,7 +92,7 @@ test('Removes nested blockquote one level at a time on Backspace', async () => {
 	expect(within(editor).queryAllByRole('blockquote')).toHaveLength(0);
 });
 
-test('Removes an empty nested blockquote on backspace after deleting its text', async () => {
+test('Removes an empty nested blockquote after its text is deleted', async () => {
 	const user = userEvent.setup();
 	await renderRichEditor({ value: `> foo\n>> bar` });
 
@@ -98,4 +113,24 @@ test('Removes an empty nested blockquote on backspace after deleting its text', 
 
 	expect(within(editor).getAllByRole('blockquote')).toHaveLength(1);
 	expect(within(editor).getByRole('blockquote')).toHaveTextContent('foo');
+});
+
+test('Reduces blockquote nesting level while preserving its text', async () => {
+	const user = userEvent.setup();
+	await renderRichEditor({ value: `> foo\n>> bar` });
+
+	const editor = screen.getByRole('textbox');
+	const quotes = within(editor).getAllByRole('blockquote');
+	expect(quotes).toHaveLength(2);
+
+	await user.click(quotes[1]);
+	setCursorPosition(quotes[1], 0);
+
+	await user.keyboard('{Backspace}');
+
+	expect(within(editor).getAllByRole('blockquote')).toHaveLength(1);
+
+	const [blockquote] = within(editor).getAllByRole('blockquote');
+	expect(blockquote).toHaveTextContent('foo');
+	expect(blockquote).toHaveTextContent('bar');
 });

--- a/packages/app/src/features/NoteEditor/RichEditor/__tests__/spec/blockquote.dom.test.ts
+++ b/packages/app/src/features/NoteEditor/RichEditor/__tests__/spec/blockquote.dom.test.ts
@@ -31,6 +31,7 @@ test('Removes an empty quote', async () => {
 
 	const editor = screen.getByRole('textbox');
 	const quote = within(editor).getByRole('blockquote');
+	expect(quote).toHaveTextContent('');
 
 	await user.click(quote);
 	await user.keyboard('{Backspace}');
@@ -67,6 +68,8 @@ test('Removes nested quote after deleting its text', async () => {
 	const quotes = within(editor).getAllByRole('blockquote');
 	expect(quotes).toHaveLength(2);
 	expect(quotes[0]).toContainElement(quotes[1]);
+	expect(quotes[0]).toHaveTextContent('foo');
+	expect(quotes[1]).toHaveTextContent('bar');
 
 	// Delete the text
 	await user.click(quotes[1]);
@@ -97,8 +100,6 @@ test('Reduces quote nesting level while preserving its text', async () => {
 	await user.click(quotes[1]);
 	setCursorPosition(quotes[1], 0);
 	await user.keyboard('{Backspace}');
-
-	expect(within(editor).getAllByRole('blockquote')).toHaveLength(1);
 
 	const updatedQuote = within(editor).getAllByRole('blockquote');
 	expect(updatedQuote).toHaveLength(1);

--- a/packages/app/src/features/NoteEditor/RichEditor/__tests__/spec/blockquote.dom.test.ts
+++ b/packages/app/src/features/NoteEditor/RichEditor/__tests__/spec/blockquote.dom.test.ts
@@ -4,7 +4,7 @@ import userEvent from '@testing-library/user-event';
 import { renderRichEditor } from '../utils/renderRichEditor';
 import { selectContent, setCursorPosition } from '../utils/utils';
 
-test('Creates a blockquote from selected text', async () => {
+test('Creates a quote from selected text', async () => {
 	const richEditor = await renderRichEditor({ value: 'cat' });
 
 	const editor = screen.getByRole('textbox');
@@ -12,16 +12,9 @@ test('Creates a blockquote from selected text', async () => {
 	await richEditor.insert({ type: 'quote' });
 
 	expect(within(editor).getByRole('blockquote')).toHaveTextContent('cat');
-
-	selectContent(editor, 'cat');
-	await richEditor.insert({ type: 'quote' });
-
-	const quotes = within(editor).getAllByRole('blockquote');
-	expect(quotes).toHaveLength(2);
-	expect(quotes[1]).toHaveTextContent('cat');
 });
 
-test('Removes an empty blockquote when', async () => {
+test('Removes an empty quote', async () => {
 	const user = userEvent.setup();
 	await renderRichEditor({ value: '>' });
 
@@ -32,16 +25,17 @@ test('Removes an empty blockquote when', async () => {
 	await user.keyboard('{Backspace}');
 
 	expect(within(editor).queryByRole('blockquote')).not.toBeInTheDocument();
-	expect(within(editor).queryByRole('paragraph')).toHaveTextContent('');
+	expect(editor).toHaveTextContent('');
 });
 
-test('Removes a blockquote while preserving its text', async () => {
+test('Removes a quote while preserving its text', async () => {
 	const user = userEvent.setup();
 	await renderRichEditor({ value: '> Bob' });
 
 	const editor = screen.getByRole('textbox');
 	const quote = within(editor).getByRole('blockquote');
 
+	// Set the cursor position at the start of the text
 	await user.click(quote);
 	setCursorPosition(quote, 0);
 	await user.keyboard('{Backspace}');
@@ -50,7 +44,7 @@ test('Removes a blockquote while preserving its text', async () => {
 	expect(editor).toHaveTextContent('Bob');
 });
 
-test('Removes a blockquote after its text is deleted', async () => {
+test('Removes an empty quote after deleting its text', async () => {
 	const user = userEvent.setup();
 	await renderRichEditor({ value: '> text' });
 
@@ -62,15 +56,16 @@ test('Removes a blockquote after its text is deleted', async () => {
 	await user.click(quote);
 	selectContent(quote, 'text');
 
-	// First press deletes the text, second press removes the blockquote
+	// The first press deletes the text; the second press removes the quote
 	await user.keyboard('{Backspace}');
-	await user.keyboard('{Backspace}');
-
-	expect(within(editor).queryByRole('blockquote')).not.toBeInTheDocument();
 	expect(within(editor).queryByText('text')).not.toBeInTheDocument();
+	expect(within(editor).getByRole('blockquote')).toHaveTextContent('');
+
+	await user.keyboard('{Backspace}');
+	expect(within(editor).queryByRole('blockquote')).not.toBeInTheDocument();
 });
 
-test('Removes one blockquote nesting level at a time', async () => {
+test('Removes one quote nesting level at a time', async () => {
 	const user = userEvent.setup();
 	await renderRichEditor({ value: '>>>' });
 
@@ -78,11 +73,8 @@ test('Removes one blockquote nesting level at a time', async () => {
 	const quotes = within(editor).getAllByRole('blockquote');
 	expect(quotes).toHaveLength(3);
 
-	// Delete the nested blockquote
 	await user.click(quotes[2]);
 	await user.keyboard('{Backspace}');
-
-	expect(quotes[2]).not.toBeInTheDocument();
 	expect(within(editor).getAllByRole('blockquote')).toHaveLength(2);
 
 	await user.keyboard('{Backspace}');
@@ -92,7 +84,7 @@ test('Removes one blockquote nesting level at a time', async () => {
 	expect(within(editor).queryAllByRole('blockquote')).toHaveLength(0);
 });
 
-test('Removes an empty nested blockquote after its text is deleted', async () => {
+test('Removes an empty nested quote after deleting its text', async () => {
 	const user = userEvent.setup();
 	await renderRichEditor({ value: `> foo\n>> bar` });
 
@@ -108,14 +100,13 @@ test('Removes an empty nested blockquote after its text is deleted', async () =>
 	expect(quotes[1]).toHaveTextContent('');
 	expect(within(editor).getAllByRole('blockquote')).toHaveLength(2);
 
-	// The second press should remove the blockquote
+	// The second press should remove the nested quote
 	await user.keyboard('{Backspace}');
-
 	expect(within(editor).getAllByRole('blockquote')).toHaveLength(1);
 	expect(within(editor).getByRole('blockquote')).toHaveTextContent('foo');
 });
 
-test('Reduces blockquote nesting level while preserving its text', async () => {
+test('Reduces quote nesting level while preserving its text', async () => {
 	const user = userEvent.setup();
 	await renderRichEditor({ value: `> foo\n>> bar` });
 
@@ -123,14 +114,14 @@ test('Reduces blockquote nesting level while preserving its text', async () => {
 	const quotes = within(editor).getAllByRole('blockquote');
 	expect(quotes).toHaveLength(2);
 
+	// Set the cursor position at the start of the text
 	await user.click(quotes[1]);
 	setCursorPosition(quotes[1], 0);
-
 	await user.keyboard('{Backspace}');
 
 	expect(within(editor).getAllByRole('blockquote')).toHaveLength(1);
 
-	const [blockquote] = within(editor).getAllByRole('blockquote');
-	expect(blockquote).toHaveTextContent('foo');
-	expect(blockquote).toHaveTextContent('bar');
+	const [quote] = within(editor).getAllByRole('blockquote');
+	expect(quote).toHaveTextContent('foo');
+	expect(quote).toHaveTextContent('bar');
 });

--- a/packages/app/src/features/NoteEditor/RichEditor/plugins/EditorPanelPlugin/utils/tree.tsx
+++ b/packages/app/src/features/NoteEditor/RichEditor/plugins/EditorPanelPlugin/utils/tree.tsx
@@ -4,7 +4,6 @@ import {
 	$getSelection,
 	$hasAncestor,
 	$isBlockElementNode,
-	$isParagraphNode,
 	$isRangeSelection,
 	$isRootNode,
 	$isTextNode,
@@ -91,19 +90,6 @@ export const $wrapNodes = (createElement: (nodes: LexicalNode[]) => ElementNode)
 	const anchor = start.getNode();
 	if ($isRootNode(anchor)) {
 		// Handle case with empty editor state
-		// When a new note is initialized, an empty paragraph is created.
-		// Replace the empty paragraph with the element being created to avoid an unnecessary empty line.
-		const targetChild = anchor.getFirstChild();
-		if (
-			targetChild &&
-			$isParagraphNode(targetChild) &&
-			targetChild.getChildrenSize() === 0 &&
-			anchor.getChildrenSize() === 1
-		) {
-			targetChild.replace(createElement([]));
-			return;
-		}
-
 		const paragraph = $createParagraphNode();
 		anchor.append(paragraph);
 		paragraph.append(createElement([]));

--- a/packages/app/src/features/NoteEditor/RichEditor/plugins/EditorPanelPlugin/utils/tree.tsx
+++ b/packages/app/src/features/NoteEditor/RichEditor/plugins/EditorPanelPlugin/utils/tree.tsx
@@ -4,6 +4,7 @@ import {
 	$getSelection,
 	$hasAncestor,
 	$isBlockElementNode,
+	$isParagraphNode,
 	$isRangeSelection,
 	$isRootNode,
 	$isTextNode,
@@ -90,6 +91,19 @@ export const $wrapNodes = (createElement: (nodes: LexicalNode[]) => ElementNode)
 	const anchor = start.getNode();
 	if ($isRootNode(anchor)) {
 		// Handle case with empty editor state
+		// When a new note is initialized, an empty paragraph is created.
+		// Replace the empty paragraph with the element being created to avoid an unnecessary empty line.
+		const targetChild = anchor.getFirstChild();
+		if (
+			targetChild &&
+			$isParagraphNode(targetChild) &&
+			targetChild.getChildrenSize() === 0 &&
+			anchor.getChildrenSize() === 1
+		) {
+			targetChild.replace(createElement([]));
+			return;
+		}
+
 		const paragraph = $createParagraphNode();
 		anchor.append(paragraph);
 		paragraph.append(createElement([]));

--- a/packages/app/src/features/NoteEditor/RichEditor/plugins/KeyboardControlsPlugin/KeyboardControlsPlugin.ts
+++ b/packages/app/src/features/NoteEditor/RichEditor/plugins/KeyboardControlsPlugin/KeyboardControlsPlugin.ts
@@ -3,11 +3,13 @@ import {
 	$createParagraphNode,
 	$getSelection,
 	$isParagraphNode,
+	$isRangeSelection,
 	$isTextNode,
 	BaseSelection,
 	COMMAND_PRIORITY_LOW,
 	createCommand,
 	ElementNode,
+	KEY_BACKSPACE_COMMAND,
 	KEY_ENTER_COMMAND,
 } from 'lexical';
 import { $isCodeNode } from '@lexical/code-core';
@@ -91,6 +93,39 @@ export const KeyboardControlsPlugin = () => {
 						newParagraph.select();
 
 						return true;
+					},
+					COMMAND_PRIORITY_LOW,
+				),
+				editor.registerCommand(
+					KEY_BACKSPACE_COMMAND,
+					(event) => {
+						const selection = $getSelection();
+						if (!$isRangeSelection(selection) || !selection.isCollapsed())
+							return false;
+
+						// cursor must be start of string
+						if (selection.anchor.offset !== 0) return false;
+
+						const blockElement = $getParentOfTextOnEnd(selection);
+
+						if ($isQuoteNode(blockElement)) {
+							if (blockElement.getTextContentSize() !== 0) return false;
+
+							const sibling = blockElement.getPreviousSibling();
+							if (sibling) {
+								blockElement.remove();
+								sibling.selectEnd();
+							} else {
+								const paragraph = $createParagraphNode();
+								blockElement.replace(paragraph);
+								paragraph.select();
+							}
+
+							event.preventDefault();
+							return true;
+						}
+
+						return false;
 					},
 					COMMAND_PRIORITY_LOW,
 				),

--- a/packages/app/src/features/NoteEditor/RichEditor/plugins/KeyboardControlsPlugin/KeyboardControlsPlugin.ts
+++ b/packages/app/src/features/NoteEditor/RichEditor/plugins/KeyboardControlsPlugin/KeyboardControlsPlugin.ts
@@ -1,7 +1,9 @@
 import { useEffect } from 'react';
 import {
 	$createParagraphNode,
+	$findMatchingParent,
 	$getSelection,
+	$isElementNode,
 	$isParagraphNode,
 	$isRangeSelection,
 	$isTextNode,
@@ -102,29 +104,36 @@ export const KeyboardControlsPlugin = () => {
 						const selection = $getSelection();
 						if (!$isRangeSelection(selection) || !selection.isCollapsed())
 							return false;
-						// Cursor must be start of string
 						if (selection.anchor.offset !== 0) return false;
 
-						// Handel sequential deletion of nested quotes
-						const blockElement = $getParentOfTextOnEnd(selection);
-						if (!$isQuoteNode(blockElement)) return false;
+						// Handle Backspace at the beginning of a quote: unwrap the quote or remove it if it is empty
+						const quoteNode = $getParentOfTextOnEnd(selection);
+						if (!$isQuoteNode(quoteNode)) return false;
 
-						// Skip top-level quote
-						const parent = blockElement.getParent();
-						if (!$isQuoteNode(parent)) return false;
+						// A quote can contain multiple lines, find the line containing the cursor
+						// Continue unwrapping the quote only when the cursor is in its first line,
+						// otherwise, let Lexical handle backspace
+						const cursorLine = $findMatchingParent(
+							selection.anchor.getNode(),
+							(node) => node.getParent() === quoteNode,
+						);
+						if (cursorLine && cursorLine !== quoteNode.getFirstChild())
+							return false;
 
-						const children = blockElement.getChildren();
-						const index = blockElement.getIndexWithinParent();
+						// Unwrap the quote, reducing its nesting level or removing it entirely
+						const parent = quoteNode.getParent();
+						if (!$isElementNode(parent)) return false;
 
+						const children = quoteNode.getChildren();
+						const index = quoteNode.getIndexWithinParent();
+
+						// Move the quote's children into its parent preserving their content
 						if (children.length > 0) {
 							parent.splice(index, 1, children);
-						} else {
-							blockElement.remove();
-						}
-
-						if (children[0]) {
 							children[0].selectStart();
 						} else {
+							// Empty quote - just remove it
+							quoteNode.remove();
 							parent.selectEnd();
 						}
 

--- a/packages/app/src/features/NoteEditor/RichEditor/plugins/KeyboardControlsPlugin/KeyboardControlsPlugin.ts
+++ b/packages/app/src/features/NoteEditor/RichEditor/plugins/KeyboardControlsPlugin/KeyboardControlsPlugin.ts
@@ -102,30 +102,34 @@ export const KeyboardControlsPlugin = () => {
 						const selection = $getSelection();
 						if (!$isRangeSelection(selection) || !selection.isCollapsed())
 							return false;
-
-						// cursor must be start of string
+						// Cursor must be start of string
 						if (selection.anchor.offset !== 0) return false;
 
+						// Handel sequential deletion of nested quotes
 						const blockElement = $getParentOfTextOnEnd(selection);
+						if (!$isQuoteNode(blockElement)) return false;
 
-						if ($isQuoteNode(blockElement)) {
-							if (blockElement.getTextContentSize() !== 0) return false;
+						// Skip top-level quote
+						const parent = blockElement.getParent();
+						if (!$isQuoteNode(parent)) return false;
 
-							const sibling = blockElement.getPreviousSibling();
-							if (sibling) {
-								blockElement.remove();
-								sibling.selectEnd();
-							} else {
-								const paragraph = $createParagraphNode();
-								blockElement.replace(paragraph);
-								paragraph.select();
-							}
+						const children = blockElement.getChildren();
+						const index = blockElement.getIndexWithinParent();
 
-							event.preventDefault();
-							return true;
+						if (children.length > 0) {
+							parent.splice(index, 1, children);
+						} else {
+							blockElement.remove();
 						}
 
-						return false;
+						if (children[0]) {
+							children[0].selectStart();
+						} else {
+							parent.selectEnd();
+						}
+
+						event.preventDefault();
+						return true;
 					},
 					COMMAND_PRIORITY_LOW,
 				),

--- a/packages/app/src/features/NoteEditor/RichEditor/plugins/KeyboardControlsPlugin/KeyboardControlsPlugin.ts
+++ b/packages/app/src/features/NoteEditor/RichEditor/plugins/KeyboardControlsPlugin/KeyboardControlsPlugin.ts
@@ -106,7 +106,7 @@ export const KeyboardControlsPlugin = () => {
 							return false;
 						if (selection.anchor.offset !== 0) return false;
 
-						// Handle Backspace at the beginning of a quote: unwrap the quote or remove it if it is empty
+						// Handle Backspace at the beginning of a quote: unwrap the quote or remove if it is empty
 						const quoteNode = $findMatchingParent(
 							selection.anchor.getNode(),
 							$isQuoteNode,
@@ -128,14 +128,14 @@ export const KeyboardControlsPlugin = () => {
 						if (!$isElementNode(parent)) return false;
 
 						const children = quoteNode.getChildren();
-						const index = quoteNode.getIndexWithinParent();
 
 						// Move the quote's children into its parent preserving their content
 						if (children.length > 0) {
+							const index = quoteNode.getIndexWithinParent();
 							parent.splice(index, 1, children);
 							children[0].selectStart();
 						} else {
-							// Empty quote - just remove it
+							// Remove empty quote
 							quoteNode.remove();
 							parent.selectEnd();
 						}

--- a/packages/app/src/features/NoteEditor/RichEditor/plugins/KeyboardControlsPlugin/KeyboardControlsPlugin.ts
+++ b/packages/app/src/features/NoteEditor/RichEditor/plugins/KeyboardControlsPlugin/KeyboardControlsPlugin.ts
@@ -106,7 +106,7 @@ export const KeyboardControlsPlugin = () => {
 							return false;
 						if (selection.anchor.offset !== 0) return false;
 
-						// Handle Backspace at the beginning of a quote: unwrap the quote or remove if it is empty
+						// Handle Backspace at the beginning of a quote: unwrap the quote or remove it if it is empty
 						const quoteNode = $findMatchingParent(
 							selection.anchor.getNode(),
 							$isQuoteNode,

--- a/packages/app/src/features/NoteEditor/RichEditor/plugins/KeyboardControlsPlugin/KeyboardControlsPlugin.ts
+++ b/packages/app/src/features/NoteEditor/RichEditor/plugins/KeyboardControlsPlugin/KeyboardControlsPlugin.ts
@@ -107,8 +107,11 @@ export const KeyboardControlsPlugin = () => {
 						if (selection.anchor.offset !== 0) return false;
 
 						// Handle Backspace at the beginning of a quote: unwrap the quote or remove it if it is empty
-						const quoteNode = $getParentOfTextOnEnd(selection);
-						if (!$isQuoteNode(quoteNode)) return false;
+						const quoteNode = $findMatchingParent(
+							selection.anchor.getNode(),
+							$isQuoteNode,
+						);
+						if (!quoteNode) return false;
 
 						// A quote can contain multiple lines, find the line containing the cursor
 						// Continue unwrapping the quote only when the cursor is in its first line,


### PR DESCRIPTION
Closes #82 

Changes:
- Added tests
- Fixed deleting quotes 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Improved blockquote editing in the rich-text editor.
  - Backspace at the start of a quote now removes empty quotes or reduces nested quote levels while preserving text.

- **Bug Fixes**
  - Prevented unexpected quote formatting when deleting content at quote boundaries.

- **Tests**
  - Added coverage for creating, deleting, and nesting blockquotes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->